### PR TITLE
feat: add kiro shell integration

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -14,3 +14,6 @@ fi
 
 # Added by Windsurf
 export PATH="/Users/takumiakasaka/.codeium/windsurf/bin:$PATH"
+
+# Added by kiro shell integration
+[[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"


### PR DESCRIPTION
## 概要
kiroターミナル用のシェル統合機能を追加しました。これにより高度な機能と改善されたターミナル体験が利用できるようになります。

## 変更点
- .zshrcにkiroシェル統合の設定を追加
- TERM_PROGRAMがkiroの場合のみ統合機能を有効化
- kiro --locate-shell-integration-path zshを使用してパスを動的に取得

## 注意点
この変更はkiroターミナルを使用している場合のみ影響し、他のターミナルには影響しません。