### PR TITLE
fix: stabilize skhd fallback and Atuin init

### DIFF
--- a/.skhdrc
+++ b/.skhdrc
@@ -5,15 +5,15 @@ hyper - k : yabai -m window --focus north || yabai -m display --focus north
 hyper - l : yabai -m window --focus east || yabai -m display --focus east
 
 # swap window
-hyper - y : yabai -m window --swap west  || $(yabai -m window --display west; yabai -m display --focus west)
-hyper - u : yabai -m window --swap south  || $(yabai -m window --display south; yabai -m display --focus south)
-hyper - i : yabai -m window --swap north  || $(yabai -m window --display north; yabai -m display --focus north)
-hyper - o : yabai -m window --swap east  || $(yabai -m window --display east; yabai -m display --focus east)
+hyper - y : yabai -m window --swap west  || { yabai -m window --display west;  yabai -m display --focus west; }
+hyper - u : yabai -m window --swap south || { yabai -m window --display south; yabai -m display --focus south; }
+hyper - i : yabai -m window --swap north || { yabai -m window --display north; yabai -m display --focus north; }
+hyper - o : yabai -m window --swap east  || { yabai -m window --display east;  yabai -m display --focus east; }
 
 # increase window size
 meh - h : yabai -m window --resize left:-20:0
 meh - j : yabai -m window --resize bottom:0:20
-meh - k : yabai -m window --resize top:0:-20:0
+meh - k : yabai -m window --resize top:0:-20
 meh - l : yabai -m window --resize right:20:0
 
 # decrease window size

--- a/.zsh/init.zsh
+++ b/.zsh/init.zsh
@@ -27,9 +27,8 @@ source /Users/takumiakasaka/.docker/init-zsh.sh || true
 eval "$(starship init zsh)"
 
 ## atuin setting
-# FIXME: maybe remove
-# NOTE: brew uninstall atuin
-eval "$(atuin init zsh)"
+# Keep only one initialization to avoid conflicts
+# eval "$(atuin init zsh)"
 eval "$(atuin init zsh --disable-ctrl-r)"
 
 ## tmux setting


### PR DESCRIPTION
## Summary
- Fix invalid command substitution in `.skhdrc` fallback; use brace grouping
- Correct yabai `--resize` argument count for `top`
- Remove duplicate Atuin initialization to prevent keybinding conflicts

## Context
- `.skhdrc` had `|| $(...)` which evaluates output as a command; intended fallback should be a command group
- `yabai -m window --resize top:0:-20:0` had 4 segments; yabai accepts 3
- Atuin was initialized twice, causing potential duplicate widgets/bindings

## Risk
Low. Only improves correctness and stability.

## Test plan
- Reload skhd: `skhd --reload`; verify swap fallback and resize operations
- Start new zsh session; ensure Atuin history still works and Ctrl-R remains disabled