### PR TITLE
feat: add automatic formatting hooks for Go and TypeScript files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -95,5 +95,22 @@
   "statusLine": {
     "type": "command",
     "command": "npx ccusage@latest statusline"
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".go\"))' | xargs -r -I {} sh -c 'gofmt -w \"$1\" && goimports -w \"$1\"' _ {}"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".ts\") or endswith(\".tsx\"))' | xargs -r -I {} sh -c 'npx prettier --write \"$1\"' _ {}"
+          }
+        ]
+      }
+    ]
   }
 }


### PR DESCRIPTION
## 概要
Claude Code での Go および TypeScript ファイル編集時に自動フォーマット機能を追加

## 変更点
- `.claude/settings.json` に PostToolUse フックを追加
- Go ファイル (.go) 用の自動フォーマット設定
  - `gofmt` でコードフォーマット
  - `goimports` でインポート整理
- TypeScript ファイル (.ts, .tsx) 用の自動フォーマット設定
  - `prettier` でコードフォーマット
- Write, Edit, MultiEdit ツール操作後に自動実行

## 注意点
- 対象ツールは Write, Edit, MultiEdit のみ
- Go 開発時は goimports のインストールが必要
- TypeScript 開発時は prettier の利用可能性が前提

🤖 Generated with [Claude Code](https://claude.ai/code)