### PR TITLE
refactor: unify skill files to English

### DIFF
--- a/.claude/skills/codex-design/SKILL.md
+++ b/.claude/skills/codex-design/SKILL.md
@@ -6,12 +6,12 @@ description: |
 
 # Codex Design Consultation
 
-## 🎯 Purpose
+## Purpose
 
-**設計段階でのCodex相談**: Consult with Codex before making complex design decisions.
+**Design-phase Codex consultation**: Consult with Codex before making complex design decisions.
 Get expert validation, alternative approaches, and risk assessment early in the development process.
 
-## 📋 When to Use
+## When to Use
 
 ### Mandatory Triggers
 - Introducing implementation patterns NOT found in existing codebase
@@ -27,7 +27,7 @@ Get expert validation, alternative approaches, and risk assessment early in the 
 - Distributed system component design
 - Complex algorithm implementation
 
-## 🔄 Consultation Flow
+## Consultation Flow
 
 ### Step 1: Problem Analysis
 
@@ -73,63 +73,63 @@ Execute Codex in read-only sandbox for design review:
 codex exec --model gpt-5.4 --sandbox read-only "$(cat <<'EOF'
 # Design Consultation Request
 
+All string fields (reasoning, risks, recommendations, guidance) must be in Japanese.
+
 ## Context
-[プロジェクトの概要と現在の状況]
+[Project overview and current situation]
 
 ## Problem Statement
-[解決したい問題の詳細な説明]
+[Detailed description of the problem to solve]
 
 ## Constraints
-- Performance: [パフォーマンス要件]
-- Security: [セキュリティ要件]
-- Scalability: [スケーラビリティ要件]
-- Maintainability: [保守性要件]
-- Team: [チームのスキルセット]
-- Timeline: [スケジュール制約]
+- Performance: [Performance requirements]
+- Security: [Security requirements]
+- Scalability: [Scalability requirements]
+- Maintainability: [Maintainability requirements]
+- Team: [Team skillset]
+- Timeline: [Schedule constraints]
 
 ## Proposed Design Options
 
-### Option 1: [アプローチ名]
-[詳細な説明]
+### Option 1: [Approach name]
+[Detailed description]
 
 **Pros:**
-- [メリット1]
-- [メリット2]
+- [Advantage 1]
+- [Advantage 2]
 
 **Cons:**
-- [デメリット1]
-- [デメリット2]
+- [Drawback 1]
+- [Drawback 2]
 
-### Option 2: [アプローチ名]
-[詳細な説明]
+### Option 2: [Approach name]
+[Detailed description]
 ...
 
-### Option 3: [アプローチ名]
-[詳細な説明]
+### Option 3: [Approach name]
+[Detailed description]
 ...
 
 ## Existing Codebase Patterns
-[既存のコードベースで使用されているパターン]
+[Patterns used in existing codebase]
 
 ## Questions for Codex
 
-1. 各アプローチの妥当性評価
-2. 見落としている潜在的な問題点
-3. 推奨されるアプローチとその理由
-4. 実装時の注意点
-5. 類似プロジェクトでの成功/失敗事例
+1. Validity assessment for each approach
+2. Overlooked potential issues
+3. Recommended approach and reasoning
+4. Implementation considerations
+5. Success/failure cases from similar projects
 
-## Required Output Format (JSON in Japanese)
-
-以下のJSON形式で回答してください:
+## Required Output Format (JSON, values in Japanese)
 
 {
   "recommended_option": "Option 1|Option 2|Option 3|Alternative",
-  "reasoning": "推奨理由の詳細説明(日本語)",
+  "reasoning": "Detailed reasoning for recommendation (Japanese)",
   "risk_assessment": {
     "option_1": {
-      "technical_risks": ["リスク1", "リスク2"],
-      "mitigation": ["対策1", "対策2"]
+      "technical_risks": ["Risk 1", "Risk 2"],
+      "mitigation": ["Mitigation 1", "Mitigation 2"]
     },
     "option_2": { ... },
     "option_3": { ... }
@@ -137,27 +137,27 @@ codex exec --model gpt-5.4 --sandbox read-only "$(cat <<'EOF'
   "additional_considerations": [
     {
       "category": "performance|security|maintainability|scalability",
-      "point": "考慮すべき点(日本語)",
+      "point": "Consideration point (Japanese)",
       "importance": "critical|high|medium|low"
     }
   ],
   "alternative_approach": {
-    "description": "代替アプローチの説明(Option 1-3以外に良い方法があれば)",
-    "why_better": "なぜこちらが良いか"
+    "description": "Alternative approach description (if better than Options 1-3)",
+    "why_better": "Why this is better"
   },
   "implementation_guidance": [
-    "実装時のガイダンス1",
-    "実装時のガイダンス2"
+    "Implementation guidance 1",
+    "Implementation guidance 2"
   ],
   "similar_patterns": [
     {
-      "project": "類似プロジェクト名",
-      "approach": "採用されたアプローチ",
-      "outcome": "結果(成功/失敗とその理由)"
+      "project": "Similar project name",
+      "approach": "Adopted approach",
+      "outcome": "Result (success/failure and reasons)"
     }
   ],
   "confidence": "high|medium|low",
-  "caveats": ["注意事項1", "注意事項2"]
+  "caveats": ["Caveat 1", "Caveat 2"]
 }
 EOF
 )"
@@ -173,92 +173,94 @@ Claude Code analyzes Codex's response:
 
 ### Step 5: Present to User
 
+**All user-facing output must be in Japanese.**
+
 Present comprehensive analysis to user for final decision:
 
 ```markdown
-## 設計相談結果: [問題のタイトル]
+## Design Consultation Result: [Problem Title]
 
-### 問題概要
-[解決したい問題の簡潔な説明]
+### Problem Summary
+[Brief description of the problem]
 
-### 提案した設計オプション
-1. **Option 1**: [概要]
-2. **Option 2**: [概要]
-3. **Option 3**: [概要]
+### Proposed Design Options
+1. **Option 1**: [Summary]
+2. **Option 2**: [Summary]
+3. **Option 3**: [Summary]
 
-### Codex推奨
-- **推奨アプローチ**: Option 2
-- **信頼度**: High
-- **推奨理由**:
-  [Codexの推奨理由を日本語で説明]
+### Codex Recommendation
+- **Recommended approach**: Option 2
+- **Confidence**: High
+- **Reasoning**:
+  [Codex reasoning explained]
 
-### リスク評価
+### Risk Assessment
 
-#### Option 1: [名前]
-- **技術的リスク**:
-  - [リスク1]
-  - [リスク2]
-- **リスク軽減策**:
-  - [対策1]
-  - [対策2]
+#### Option 1: [Name]
+- **Technical risks**:
+  - [Risk 1]
+  - [Risk 2]
+- **Mitigations**:
+  - [Mitigation 1]
+  - [Mitigation 2]
 
-#### Option 2: [名前] ⭐ 推奨
-- **技術的リスク**:
-  - [リスク1]
-- **リスク軽減策**:
-  - [対策1]
+#### Option 2: [Name] (recommended)
+- **Technical risks**:
+  - [Risk 1]
+- **Mitigations**:
+  - [Mitigation 1]
 
-#### Option 3: [名前]
-- **技術的リスク**:
-  - [リスク1]
-  - [リスク2]
-- **リスク軽減策**:
-  - [対策1]
+#### Option 3: [Name]
+- **Technical risks**:
+  - [Risk 1]
+  - [Risk 2]
+- **Mitigations**:
+  - [Mitigation 1]
 
-### 追加考慮事項
+### Additional Considerations
 
 #### Critical
-- [重要な考慮点1]
+- [Critical consideration 1]
 
 #### High
-- [高優先度の考慮点1]
-- [高優先度の考慮点2]
+- [High priority consideration 1]
+- [High priority consideration 2]
 
 #### Medium
-- [中優先度の考慮点1]
+- [Medium priority consideration 1]
 
-### 代替アプローチ (Codex提案)
-[Codexが提案した代替案があれば]
+### Alternative Approach (Codex proposal)
+[Alternative proposed by Codex, if any]
 
-**なぜ良いか**: [理由]
+**Why better**: [Reasoning]
 
-### 実装ガイダンス
-1. [実装時の注意点1]
-2. [実装時の注意点2]
-3. [実装時の注意点3]
+### Implementation Guidance
+1. [Implementation note 1]
+2. [Implementation note 2]
+3. [Implementation note 3]
 
-### 類似プロジェクトの事例
-- **プロジェクト**: [名前]
-  - **アプローチ**: [採用手法]
-  - **結果**: [成功/失敗の理由]
+### Similar Project Examples
+- **Project**: [Name]
+  - **Approach**: [Adopted method]
+  - **Result**: [Success/failure reasons]
 
-### 注意事項
-- [注意事項1]
-- [注意事項2]
+### Caveats
+- [Caveat 1]
+- [Caveat 2]
 
-### Claude Codeの所見
-[Codexの推奨を踏まえた、プロジェクト固有の考察]
+### Claude Code Observations
+[Project-specific insights considering Codex recommendation]
 
-どのアプローチで進めますか? または、さらに詳細を検討しますか?
+Which approach should we proceed with? Or investigate further?
 ```
 
-## 🔍 Specific Use Cases
+## Specific Use Cases
 
 ### Use Case 1: Database Schema Design
 
 ```markdown
 ## Problem
-新しいマルチテナント機能のためのデータベース設計
+Database design for new multi-tenant feature
 
 ## Options
 1. Single database with tenant_id column
@@ -278,7 +280,7 @@ Option 3 (Schema per tenant) for this scale
 
 ```markdown
 ## Problem
-新しいマイクロサービス間のAPI設計
+API design for new microservice communication
 
 ## Options
 1. REST with JSON
@@ -298,7 +300,7 @@ Option 2 (gRPC) for internal services
 
 ```markdown
 ## Problem
-React アプリケーションの状態管理
+State management for React application
 
 ## Options
 1. Redux Toolkit
@@ -314,7 +316,7 @@ Option 2 (Zustand) for this project size
 - Mitigation: Keep state logic modular for easier migration
 ```
 
-## 🚨 Error Handling
+## Error Handling
 
 ### Codex Timeout
 - Wait up to 10 minutes (10 polls)
@@ -332,7 +334,7 @@ Option 2 (Zustand) for this project size
 - Provides reasoning for both perspectives
 - Lets user make informed decision
 
-## 📊 Output Quality Indicators
+## Output Quality Indicators
 
 ### High Confidence Output
 - Clear recommendation with strong reasoning
@@ -346,7 +348,7 @@ Option 2 (Zustand) for this project size
 - Suggests gathering more information
 - Recommends prototyping or spike
 
-## 🔧 Configuration Parameters
+## Configuration Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -356,16 +358,16 @@ Option 2 (Zustand) for this project size
 | require_risk_assessment | true | Require risk analysis for each option |
 | include_examples | true | Include similar project examples |
 
-## 🎯 Success Criteria
+## Success Criteria
 
 Consultation is successful when:
-- ✅ Codex provides clear recommendation
-- ✅ All options have risk assessment
-- ✅ Implementation guidance provided
-- ✅ User has sufficient information to decide
-- ✅ Potential pitfalls identified
+- Codex provides clear recommendation
+- All options have risk assessment
+- Implementation guidance provided
+- User has sufficient information to decide
+- Potential pitfalls identified
 
-## 📝 Best Practices
+## Best Practices
 
 ### Before Consultation
 1. Clearly define the problem and constraints
@@ -385,7 +387,7 @@ Consultation is successful when:
 3. Share decision with team
 4. Reference consultation in implementation
 
-## ⚠️ Important Reminders
+## Important Reminders
 
 1. **Use early** - Consult before writing code, not after
 2. **Be specific** - Provide detailed context and constraints

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -6,12 +6,12 @@ description: |
 
 # Codex Automatic Review Gate
 
-## 🎯 Purpose
+## Purpose
 
-**自動レビューゲート**: Automatically executed before Claude Code asks for user confirmation.
+**Automatic review gate**: Automatically executed before Claude Code asks for user confirmation.
 Quality gate ensuring all blocking issues are resolved before presenting to user.
 
-## 📋 Execution Flow
+## Execution Flow
 
 ### Step 0: Pre-Review Analysis
 
@@ -46,10 +46,10 @@ codex exec --model gpt-5.4 --sandbox read-only \
   "$(cat <<'EOF'
 # Review Request
 
-すべての文字列フィールド（summary, problem, recommendation, notes_for_next_review）は日本語で記述してください。
+All string fields (summary, problem, recommendation, notes_for_next_review) must be in Japanese.
 
 ## Context
-[Claude Code provides implementation summary in Japanese]
+[Claude Code provides implementation summary]
 
 ## Changed Files
 [List of modified files with line counts]
@@ -97,7 +97,7 @@ rm -f "$REVIEW_OUT"
 **Important: Wait for Codex completion**
 
 - Poll every 60 seconds (max 20 times = 20 minutes)
-- Progress log: `[Codexレビュー中] Poll 5/20 (経過時間: 5分)...`
+- Progress log: `[Codex review] Poll 5/20 (elapsed: 5min)...`
 - Do NOT proceed to other tasks while waiting
 - On timeout: Split files and retry
 
@@ -112,7 +112,7 @@ while current_iteration < max_iterations:
     review_result = execute_codex_review()
 
     if review_result["ok"] == True:
-        # ✅ Review passed - proceed to user presentation
+        # Review passed - proceed to user presentation
         break
 
     # Fix all blocking issues
@@ -170,29 +170,29 @@ const subagent_reviews = await Promise.all([
 
 **Cross-check prompt (after parallel reviews):**
 ```
-並列レビューが完了しました。以下の横断的な問題を確認してください:
+Parallel reviews complete. Verify the following cross-cutting concerns:
 
-## 各グループのレビュー結果
-[Group 1 結果]
-[Group 2 結果]
-[Group 3 結果]
-[Group 4 結果]
+## Review Results per Group
+[Group 1 results]
+[Group 2 results]
+[Group 3 results]
+[Group 4 results]
 
-## 横断確認事項
-- Interface consistency: APIインターフェースの整合性
-- Error handling consistency: エラーハンドリングの一貫性
-- Authorization coverage: 認可・認証の漏れ
-- API compatibility: 既存APIとの互換性
-- Cross-cutting concerns: ログ、監視、セキュリティの横断的実装
+## Cross-cutting Verification
+- Interface consistency: API interface coherence
+- Error handling consistency: Uniform error handling
+- Authorization coverage: No auth/authz gaps
+- API compatibility: Compatibility with existing APIs
+- Cross-cutting concerns: Logging, monitoring, security
 
-上記の観点で横断的なblocking issueがあれば指摘してください。
+Report any cross-cutting blocking issues.
 ```
 
-## 🚨 Error Handling
+## Error Handling
 
 ### Codex Timeout
 1. Split files into half and retry
-2. If retry also times out → Skip that section, document in report as "未レビュー"
+2. If retry also times out → Skip that section, document as "not reviewed"
 3. Continue with remaining files
 
 ### Codex API Failure
@@ -205,111 +205,113 @@ const subagent_reviews = await Promise.all([
 - Report test failures to user with context
 - Let user decide whether to proceed
 
-## 📊 Output Format to User
+## Output Format to User
+
+**All user-facing output must be in Japanese.**
 
 ### Success Case (ok: true)
 
 ```markdown
-## [実装内容のタイトル] ✅
+## [Implementation Title]
 
-[Claude Codeによる実装内容の説明]
+[Claude Code implementation description]
 
-### Codexレビュー結果
-- **ステータス**: ✅ ok
-- **反復回数**: 2/5
-- **レビュー規模**: medium (7ファイル、280行)
-- **修正項目**:
-  1. `auth.py:42-45` - 認可チェックの追加 (security/blocking)
-  2. `api.py:128` - nullチェック改善 (correctness/blocking)
-  3. `utils.py:89` - エラーハンドリングの統一 (maintainability/blocking)
+### Codex Review Result
+- **Status**: ok
+- **Iterations**: 2/5
+- **Review scope**: medium (7 files, 280 lines)
+- **Fixed items**:
+  1. `auth.py:42-45` - Added authorization check (security/blocking)
+  2. `api.py:128` - Improved null check (correctness/blocking)
+  3. `utils.py:89` - Unified error handling (maintainability/blocking)
 
-### Advisory(参考・任意対応)
-- `main.py:67` - 関数名が冗長、リファクタ推奨 (style/advisory)
-- `config.py:15` - マジックナンバーを定数化推奨 (maintainability/advisory)
+### Advisory (optional)
+- `main.py:67` - Verbose function name, refactor recommended (style/advisory)
+- `config.py:15` - Extract magic number to constant (maintainability/advisory)
 
-### 未レビュー
-- なし
+### Not Reviewed
+- None
 
-この内容で進めてよろしいですか?
+Proceed with this?
 ```
 
 ### Failure Case (ok: false after max iterations)
 
 ```markdown
-## [実装内容のタイトル] ⚠️
+## [Implementation Title]
 
-[実装内容の説明]
+[Implementation description]
 
-### Codexレビュー結果
-- **ステータス**: ⚠️ 未解決issue残存
-- **反復回数**: 5/5 (上限到達)
-- **レビュー規模**: small (2ファイル、150行)
+### Codex Review Result
+- **Status**: Unresolved issues remain
+- **Iterations**: 5/5 (limit reached)
+- **Review scope**: small (2 files, 150 lines)
 
-### 未解決のBlocking Issues
+### Unresolved Blocking Issues
 1. `database.py:89-92` (security/blocking)
-   - **問題**: SQLインジェクション脆弱性の可能性
-   - **詳細**: ユーザー入力を直接クエリに埋め込んでいます
-   - **推奨**: パラメータ化クエリまたはORMを使用してください
-   - **対応方針**: [Claude Codeの判断・提案]
+   - **Problem**: Potential SQL injection vulnerability
+   - **Detail**: User input directly embedded in query
+   - **Recommendation**: Use parameterized query or ORM
+   - **Approach**: [Claude Code's proposal]
 
 2. `auth.py:156-160` (correctness/blocking)
-   - **問題**: トークン検証のロジックエラー
-   - **詳細**: 期限切れトークンが通過する可能性があります
-   - **推奨**: 期限チェックを追加し、テストケースで確認してください
-   - **対応方針**: [Claude Codeの判断・提案]
+   - **Problem**: Token validation logic error
+   - **Detail**: Expired tokens may pass validation
+   - **Recommendation**: Add expiry check and verify with test cases
+   - **Approach**: [Claude Code's proposal]
 
-### Advisory(参考)
-- `utils.py:45` - ログレベルの見直し推奨 (maintainability/advisory)
+### Advisory
+- `utils.py:45` - Review log level (maintainability/advisory)
 
-これらの問題を解決してから進めるべきですが、どうしますか?
-- [A] 問題を修正してから再レビュー
-- [B] この状態で一旦確認
-- [C] 特定のissueのみ対応
+These issues should be resolved before proceeding. What would you like to do?
+- [A] Fix issues and re-review
+- [B] Review current state as-is
+- [C] Fix specific issues only
 ```
 
 ### Large Scope with Parallel Reviews
 
 ```markdown
-## [実装内容のタイトル] ✅
+## [Implementation Title]
 
-[実装内容の説明]
+[Implementation description]
 
-### Codexレビュー結果
-- **ステータス**: ✅ ok
-- **反復回数**: 3/5
-- **レビュー規模**: large (15ファイル、820行)
-- **並列レビュー**: 4グループ、各グループ独立実行
+### Codex Review Result
+- **Status**: ok
+- **Iterations**: 3/5
+- **Review scope**: large (15 files, 820 lines)
+- **Parallel reviews**: 4 groups, each reviewed independently
 
-#### グループ別レビューサマリ
-1. **認証層** (3ファイル): 1回の修正でok
-   - JWT検証ロジックの改善
-2. **API層** (4ファイル): 2回の修正でok
-   - エラーレスポンス形式の統一
-   - 入力バリデーション追加
-3. **DB層** (5ファイル): 3回の修正でok
-   - トランザクション境界の修正
-   - インデックス最適化
-4. **UI層** (3ファイル): 1回でok
-   - 軽微なアクセシビリティ改善
+#### Per-Group Review Summary
+1. **Auth layer** (3 files): ok after 1 fix
+   - JWT validation logic improvement
+2. **API layer** (4 files): ok after 2 fixes
+   - Unified error response format
+   - Added input validation
+3. **DB layer** (5 files): ok after 3 fixes
+   - Fixed transaction boundaries
+   - Index optimization
+4. **UI layer** (3 files): ok on first pass
+   - Minor accessibility improvement
 
-#### 横断チェック結果
-- Interface整合性: ✅ 問題なし
-- Error handling一貫性: ✅ 統一済み
-- 認可カバレッジ: ✅ 完全
-- API互換性: ✅ 破壊的変更なし
+#### Cross-check Results
+- Interface consistency: No issues
+- Error handling consistency: Unified
+- Authorization coverage: Complete
+- API compatibility: No breaking changes
 
-### 主な修正項目
-1. トランザクション境界の適切な設定 (correctness/blocking)
-2. 全APIエンドポイントへの入力バリデーション追加 (security/blocking)
-3. エラーレスポンス形式の統一 (maintainability/blocking)
+### Key Fixes
+1. Proper transaction boundary setup (correctness/blocking)
+2. Input validation on all API endpoints (security/blocking)
+3. Unified error response format (maintainability/blocking)
 
-### Advisory(参考)
-- いくつかの関数が長すぎる、分割推奨 (maintainability/advisory)
+### Advisory
+- Some functions too long, split recommended (maintainability/advisory)
 
-この内容で進めてよろしいですか?
+Proceed with this?
 ```
 
-## 🔧 Configuration Parameters
+## Configuration Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -321,7 +323,7 @@ const subagent_reviews = await Promise.all([
 | max_files_per_subagent | 5 | Files per Subagent in parallel mode |
 | max_lines_per_subagent | 300 | Lines per Subagent in parallel mode |
 
-## 🔗 Integration Points
+## Integration Points
 
 ### With PLANS.md
 Automatically integrated into implementation milestones:
@@ -330,13 +332,13 @@ Automatically integrated into implementation milestones:
 ## Phase 1: Authentication Implementation
 - [ ] Implement OAuth2 flow
 - [ ] Write tests
-- [ ] **[AUTO]** codex-review gate ← Automatically inserted
+- [ ] **[AUTO]** codex-review gate
 - [ ] User confirmation
 
 ## Phase 2: API Development
 - [ ] Implement REST endpoints
 - [ ] Add input validation
-- [ ] **[AUTO]** codex-review gate ← Automatically inserted
+- [ ] **[AUTO]** codex-review gate
 - [ ] User confirmation
 ```
 
@@ -356,7 +358,7 @@ fi
 # (Implementation depends on project setup)
 ```
 
-## 📝 Internal Processing Notes
+## Internal Processing Notes
 
 ### Codex Prompt Construction
 Claude Code constructs the prompt dynamically based on:
@@ -381,7 +383,7 @@ Claude Code constructs the prompt dynamically based on:
 5. **Testing** blocking issues
 6. Advisory issues (document only, don't fix automatically)
 
-## 📝 Plan Review Mode
+## Plan Review Mode
 
 When triggered from **ExitPlanMode** (via quality-gate Step 1), Codex reviews the **plan itself** instead of code changes.
 
@@ -402,22 +404,22 @@ codex exec --model gpt-5.4 --sandbox read-only \
   "$(cat <<'EOF'
 # Plan Review Request
 
-すべての文字列フィールド（summary, section, problem, recommendation, suggestions）は日本語で記述してください。
+All string fields (summary, section, problem, recommendation, suggestions) must be in Japanese.
 
 ## Plan Content
 [Contents of .claude/plans/{task-name}.md]
 
 ## Review Focus Areas
-- **実現可能性**: 計画は技術的に実現可能か？見落としている制約はないか？
-- **リスク評価**: 潜在的なリスクや問題点は適切に特定されているか？
-- **代替案**: より良いアプローチはないか？
-- **影響範囲**: 変更の影響範囲は正確に把握されているか？副作用は？
-- **依存関係**: ステップ間の依存関係は正しいか？順序は適切か？
-- **テスト戦略**: テスト方針は十分か？
+- **Feasibility**: Is the plan technically feasible? Any overlooked constraints?
+- **Risk assessment**: Are potential risks and issues properly identified?
+- **Alternatives**: Are there better approaches?
+- **Impact scope**: Is the change impact accurately assessed? Side effects?
+- **Dependencies**: Are step dependencies correct? Is the order appropriate?
+- **Test strategy**: Is the testing approach sufficient?
 
 ## Severity Guidelines
-- **blocking**: 計画に致命的な問題。修正が必要 → ok: false
-- **advisory**: 改善推奨だが計画として進めることは可能
+- **blocking**: Fatal issue in plan. Fix required → ok: false
+- **advisory**: Improvement recommended but plan can proceed
 EOF
 )"
 
@@ -446,25 +448,25 @@ rm -f "$PLAN_REVIEW_OUT"
 ### Output to User (Plan Review)
 
 ```markdown
-### Codex計画レビュー結果
-- **ステータス**: ✅ ok / ⚠️ 要修正
-- **反復回数**: 1/3
-- **指摘事項**: [修正した項目のリスト]
-- **改善提案**: [advisory項目のリスト]
+### Codex Plan Review Result
+- **Status**: ok / needs revision
+- **Iterations**: 1/3
+- **Fixed items**: [List of revised items]
+- **Suggestions**: [List of advisory items]
 ```
 
-## 🎯 Success Criteria
+## Success Criteria
 
 Review is considered successful when:
-- ✅ `ok: true` received from Codex
-- ✅ All blocking issues resolved
-- ✅ Tests pass (if available)
-- ✅ No timeouts or API errors
-- ✅ Cross-check complete (for large scope)
+- `ok: true` received from Codex
+- All blocking issues resolved
+- Tests pass (if available)
+- No timeouts or API errors
+- Cross-check complete (for large scope)
 
 After success, Claude Code can present to user with confidence.
 
-## ⚠️ Important Reminders
+## Important Reminders
 
 1. **ALWAYS run before user confirmation** - This is mandatory
 2. **Output in Japanese** - All user-facing text must be in Japanese

--- a/.claude/skills/difit/SKILL.md
+++ b/.claude/skills/difit/SKILL.md
@@ -14,7 +14,7 @@ Web-based Git diff viewer with AI prompt generation. Integrated into the `dev` c
 
 ## Primary Usage: dev command
 
-> `dev` は cmux ターミナル内でのみ実行可能です。通常のシェルから実行すると終了します。
+> `dev` can only be run inside a cmux terminal. It will exit if run from a regular shell.
 
 ```bash
 dev                    # Launch cmux split: difit (left) + claude (right)

--- a/.claude/skills/gemini-review/SKILL.md
+++ b/.claude/skills/gemini-review/SKILL.md
@@ -11,8 +11,8 @@ metadata:
 
 ## Purpose
 
-**独立セカンドオピニオンレビュー**: Codex-reviewと並列実行し、異なるモデル視点でのレビューを提供。
-両者の結果を突き合わせることで、見逃しを減らし信頼度を上げる。
+**Independent second-opinion review**: Runs in parallel with codex-review to provide a different model perspective.
+Cross-checking both results reduces missed issues and increases confidence.
 
 ## Execution Flow
 
@@ -20,21 +20,21 @@ metadata:
 
 **Critical: Gemini runs in non-interactive mode with -p flag**
 
-**重要: 機密ファイル除外**
-以下のパターンに一致するファイルはGeminiに送信しない:
-- `.env`, `.env.*` — 環境変数
-- `*.key`, `*.pem` — 鍵・証明書
-- `*credentials*`, `*secret*` — 認証情報
-- `*.tfvars`, `*.tfstate` — Terraform機密情報
+**Important: Sensitive file exclusion**
+Files matching the following patterns must NOT be sent to Gemini:
+- `.env`, `.env.*` — environment variables
+- `*.key`, `*.pem` — keys/certificates
+- `*credentials*`, `*secret*` — authentication data
+- `*.tfvars`, `*.tfstate` — Terraform sensitive data
 
-除外されたファイルがある場合、ユーザーに通知する:
-`⚠️ 以下のファイルは機密のためGeminiレビューから除外: [file list]`
+If files are excluded, notify user:
+`Warning: The following files were excluded from Gemini review due to sensitivity: [file list]`
 
 ```bash
 ROOT=$(git rev-parse --show-toplevel)
 REVIEW_OUT=$(mktemp "${TMPDIR:-/tmp}/gemini-review.XXXXXX")
-FALLBACK_JSON='{"ok": false, "phase": "detail", "summary": "Geminiレビュー失敗", "issues": [], "notes_for_next_review": ""}'
-SKIPPED_JSON='{"ok": true, "phase": "detail", "summary": "全ファイルが機密のためGeminiレビューをスキップ", "issues": [], "notes_for_next_review": ""}'
+FALLBACK_JSON='{"ok": false, "phase": "detail", "summary": "Gemini review failed", "issues": [], "notes_for_next_review": ""}'
+SKIPPED_JSON='{"ok": true, "phase": "detail", "summary": "All files sensitive - Gemini review skipped", "issues": [], "notes_for_next_review": ""}'
 
 # Build file lists (safe vs excluded)
 EXCLUDE_PATTERNS='\.env|\.key|\.pem|credentials|secret|\.tfvars|\.tfstate'
@@ -71,8 +71,8 @@ fi
   -p "$(cat <<EOF
 # Code Review Request
 
-あなたはコードレビューアーです。以下の変更を厳密にレビューしてください。
-すべての出力は日本語で記述してください。
+You are a code reviewer. Review the following changes strictly.
+All output must be in Japanese.
 
 ## Changed Files
 $(echo "$SAFE_FILES" | head -50)
@@ -81,19 +81,19 @@ $(echo "$SAFE_FILES" | head -50)
 $SAFE_DIFF
 
 ## Review Focus Areas
-- **Correctness**: ロジックエラー、エッジケース、null/undefinedハンドリング
-- **Security**: 脆弱性、入力バリデーション、認証・認可
-- **Performance**: ボトルネック、非効率なアルゴリズム、リソースリーク
-- **Maintainability**: 可読性、既存パターンとの一貫性
-- **Testing**: テストカバレッジ、テスト品質、不足テストケース
+- **Correctness**: Logic errors, edge cases, null/undefined handling
+- **Security**: Vulnerabilities, input validation, authentication/authorization
+- **Performance**: Bottlenecks, inefficient algorithms, resource leaks
+- **Maintainability**: Readability, consistency with existing patterns
+- **Testing**: Test coverage, test quality, missing test cases
 
 ## Output Format
 
-以下のJSON形式で正確に出力してください（コードブロックなし、JSONのみ）:
+Output exactly in the following JSON format (no code blocks, JSON only):
 
 ## Severity Definitions
-- "blocking": 必ず修正が必要。1つでもblockingがあればok: false
-- "advisory": 改善推奨。okステータスには影響しない
+- "blocking": Must be fixed. Any blocking issue → ok: false
+- "advisory": Improvement recommended. Does not affect ok status
 
 ## Category Values
 "correctness", "security", "perf", "maintainability", "testing", "style"
@@ -102,7 +102,7 @@ $SAFE_DIFF
 {
   "ok": true,
   "phase": "detail",
-  "summary": "変更に問題はありません",
+  "summary": "No issues found in changes",
   "issues": [],
   "notes_for_next_review": ""
 }
@@ -111,21 +111,21 @@ $SAFE_DIFF
 {
   "ok": false,
   "phase": "detail",
-  "summary": "セキュリティ上の問題が見つかりました",
+  "summary": "Security issues found",
   "issues": [
     {
       "severity": "blocking",
       "category": "security",
       "file": "src/auth.py",
       "lines": "42-45",
-      "problem": "SQLインジェクション脆弱性",
-      "recommendation": "パラメータ化クエリを使用してください"
+      "problem": "SQL injection vulnerability",
+      "recommendation": "Use parameterized queries"
     }
   ],
-  "notes_for_next_review": "認証周りの再確認が必要"
+  "notes_for_next_review": "Auth-related code needs re-review"
 }
 
-blockingがなければ ok: true としてください。
+If no blocking issues, set ok: true.
 EOF
 )" > "$REVIEW_OUT" 2>/dev/null
 
@@ -143,7 +143,7 @@ fi
 PARSED=$(python3 -c "
 import json, sys, re
 
-FALLBACK = '{\"ok\": false, \"phase\": \"detail\", \"summary\": \"Gemini出力のJSONパース失敗\", \"issues\": [], \"notes_for_next_review\": \"\"}'
+FALLBACK = '{\"ok\": false, \"phase\": \"detail\", \"summary\": \"Failed to parse Gemini output JSON\", \"issues\": [], \"notes_for_next_review\": \"\"}'
 
 try:
     data = json.load(open('$REVIEW_OUT'))
@@ -190,16 +190,16 @@ rm -f "$REVIEW_OUT"
 
 **Important: Wait for Gemini completion**
 
-- Gemini は通常 codex より高速（大規模コンテキスト処理が得意）
-- macOS互換タイムアウト（gtimeout/timeout/perlフォールバック）で最大5分に制限
-- Progress log: `[Geminiレビュー中] 実行中（最大5分）...`
-- On timeout: フォールバックJSONを返し、Codex結果のみで判定
+- Gemini is typically faster than Codex (good at large context processing)
+- macOS-compatible timeout (gtimeout/timeout fallback) limits to 5 minutes max
+- Progress log: `[Gemini review] Running (max 5min)...`
+- On timeout: Return fallback JSON, proceed with Codex result only
 
 ### Step 2: Result Handling
 
 Gemini review does NOT iterate independently. Results are passed back to quality-gate for merged evaluation.
 
-結果は常に以下のスキーマに従う（codex-review/review-schema.json と同一）:
+Results always follow this schema (same as codex-review/review-schema.json):
 ```json
 {
   "ok": true,
@@ -212,42 +212,44 @@ Gemini review does NOT iterate independently. Results are passed back to quality
 
 ## Error Handling
 
-**全てのエラーケースでフォールバックJSONを返す。** quality-gateが常に機械的に処理できることを保証する。
+**All error cases return fallback JSON.** This guarantees quality-gate can always process results mechanically.
 
 ### Gemini Timeout (exit code 124)
-- フォールバックJSON返却
-- Log: `⚠️ Geminiレビューがタイムアウトしました（5分超過）`
+- Return fallback JSON
+- Log: `Warning: Gemini review timed out (exceeded 5min)`
 
 ### Gemini API Failure (non-zero exit)
-- フォールバックJSON返却
-- Log: `⚠️ Gemini API呼び出しに失敗しました`
+- Return fallback JSON
+- Log: `Warning: Gemini API call failed`
 
 ### Empty Output
-- フォールバックJSON返却
-- Log: `⚠️ Geminiが空の出力を返しました`
+- Return fallback JSON
+- Log: `Warning: Gemini returned empty output`
 
 ### JSON Parse Failure
-- フォールバックJSON返却
-- Log: `⚠️ Geminiの出力をJSONとしてパースできませんでした`
+- Return fallback JSON
+- Log: `Warning: Failed to parse Gemini output as JSON`
 
 ## Output Format to User
+
+**All user-facing output must be in Japanese.**
 
 Gemini review results are shown alongside Codex results in quality-gate output:
 
 ```markdown
-### Geminiレビュー結果
-- **ステータス**: ✅ ok / ⚠️ 指摘あり / ❌ 失敗
-- **指摘件数**: blocking: N件, advisory: M件
+### Gemini Review Result
+- **Status**: ok / issues found / failed
+- **Issues**: blocking: N, advisory: M
 
-#### Gemini独自の指摘（Codexと一致しない項目）
-- `file.py:42` - [問題の説明] (category/severity)
+#### Gemini-only Issues (not found by Codex)
+- `file.py:42` - [Problem description] (category/severity)
 ```
 
 ## Important Reminders
 
-1. **並列実行**: Codex-reviewと必ず並列で実行する
-2. **機密ファイル除外**: `.env`, 鍵, 認証情報は送信前に必ず除外する
-3. **フォールバック保証**: 全エラーケースで有効なJSONを返す
-4. **非インタラクティブ**: `-p` フラグで実行、`timeout 300` で制限
-5. **日本語出力**: すべてのユーザー向けテキストは日本語
-6. **マージ判定**: 最終判定はquality-gateが行う
+1. **Parallel execution**: Always run in parallel with codex-review
+2. **Sensitive file exclusion**: Always exclude `.env`, keys, credentials before sending
+3. **Fallback guarantee**: All error cases return valid JSON
+4. **Non-interactive**: Run with `-p` flag, limit with `timeout 300`
+5. **Output in Japanese**: All user-facing text in Japanese
+6. **Merge decision**: Final decision is made by quality-gate

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -237,8 +237,8 @@ Launch both reviews simultaneously using background Subagents:
 
 ### Step 4: Merge & Evaluate Results
 
-Codex と Gemini の結果は **それぞれ独立に保持** し、既存の review-schema.json には手を加えない。
-マージ結果は `codex_result` とは **別オブジェクト** として返す（review-schema.json を汚染しない）。
+Codex and Gemini results are **kept independently** — do not modify the existing review-schema.json.
+Merge metadata is returned as a **separate object** (does not pollute review-schema.json).
 
 ```python
 def merge_reviews(codex_result, gemini_result, gemini_status):
@@ -305,23 +305,25 @@ def merge_reviews(codex_result, gemini_result, gemini_status):
 
 ### Output Format (Merged)
 
+**All user-facing output must be in Japanese.**
+
 ```markdown
-## レビュー結果
+## Review Results
 
-### Codexレビュー ✅/⚠️
-- **ステータス**: ok / 未解決issue残存
-- **反復回数**: N/5
-- **指摘件数**: blocking: N件, advisory: M件
+### Codex Review
+- **Status**: ok / unresolved issues remain
+- **Iterations**: N/5
+- **Issues**: blocking: N, advisory: M
 
-### Geminiレビュー ✅/⚠️/⏰
-- **ステータス**: ok / 指摘あり / タイムアウト
-- **指摘件数**: blocking: N件, advisory: M件
+### Gemini Review
+- **Status**: ok / issues found / timeout
+- **Issues**: blocking: N, advisory: M
 
-### クロスチェック
-- **両者一致の指摘** (信頼度: 高):
-  - `file.py:42` - [問題] (category/severity) ✅ cross-verified
-- **Gemini独自の指摘** (参考):
-  - `file.py:88` - [問題] (category/advisory) 🔍 gemini-only
+### Cross-check
+- **Agreed issues** (high confidence):
+  - `file.py:42` - [Problem] (category/severity) cross-verified
+- **Gemini-only issues** (reference):
+  - `file.py:88` - [Problem] (category/advisory) gemini-only
 ```
 
 ### Iteration Behavior

--- a/.claude/skills/security-scan/SKILL.md
+++ b/.claude/skills/security-scan/SKILL.md
@@ -5,17 +5,17 @@ description: |
   Integrates with codex-review for automatic security checks.
   Covers OWASP Top 10, common vulnerabilities, and secure coding practices.
   Output: Japanese
-trigger_keywords: security, セキュリティ, vulnerability, 脆弱性, OWASP
+trigger_keywords: security, vulnerability, OWASP
 ---
 
 # Security Scan SKILL
 
-## 🎯 Purpose
+## Purpose
 
-**セキュリティ脆弱性の検出**: Identify security vulnerabilities and ensure secure coding practices.
+**Security vulnerability detection**: Identify security vulnerabilities and ensure secure coding practices.
 Automatically invoked during codex-review for security-sensitive code.
 
-## 📋 When to Use
+## When to Use
 
 ### Automatic Triggers (via codex-review)
 - Authentication/Authorization code
@@ -31,7 +31,7 @@ Automatically invoked during codex-review for security-sensitive code.
 - Before deploying security-critical features
 - After dependency updates
 
-## 🔐 Security Focus Areas
+## Security Focus Areas
 
 ### 1. Input Validation
 **Risks:**
@@ -44,10 +44,10 @@ Automatically invoked during codex-review for security-sensitive code.
 
 **Checks:**
 ```javascript
-// ❌ VULNERABLE
+// VULNERABLE
 const query = `SELECT * FROM users WHERE id = ${userId}`;
 
-// ✅ SECURE
+// SECURE
 const query = 'SELECT * FROM users WHERE id = ?';
 db.query(query, [userId]);
 ```
@@ -62,12 +62,12 @@ db.query(query, [userId]);
 
 **Checks:**
 ```javascript
-// ❌ VULNERABLE
+// VULNERABLE
 if (user.role === 'admin') {
   // No verification of user identity
 }
 
-// ✅ SECURE
+// SECURE
 if (authenticatedUser.id === user.id && user.role === 'admin') {
   // Verify both identity and role
 }
@@ -83,11 +83,11 @@ if (authenticatedUser.id === user.id && user.role === 'admin') {
 
 **Checks:**
 ```javascript
-// ❌ VULNERABLE
+// VULNERABLE
 const password = req.body.password; // Plaintext
 localStorage.setItem('token', token); // Insecure storage
 
-// ✅ SECURE
+// SECURE
 const hashedPassword = await bcrypt.hash(password, 10);
 // Use httpOnly, secure cookies instead
 ```
@@ -104,7 +104,7 @@ const hashedPassword = await bcrypt.hash(password, 10);
 - Dependency version analysis
 - Vulnerability database lookup
 
-## 🔍 Security Scan Process
+## Security Scan Process
 
 ### Step 1: Identify Security-Sensitive Code
 
@@ -145,61 +145,63 @@ Check against OWASP Top 10:
 
 Output with remediation guidance.
 
-## 📊 Output Format to User
+## Output Format to User
+
+**All user-facing output must be in Japanese.**
 
 ```markdown
-## セキュリティスキャン結果
+## Security Scan Results
 
-### 概要
-- **スキャンファイル**: 5ファイル
-- **検出された問題**: 3件
-  - Critical: 1件
-  - High: 1件
-  - Medium: 1件
+### Summary
+- **Scanned files**: 5 files
+- **Issues found**: 3
+  - Critical: 1
+  - High: 1
+  - Medium: 1
 
-### 🚨 Critical (即座に修正が必要)
+### Critical (immediate fix required)
 
-#### 1. SQL Injection 脆弱性
-- **ファイル**: `src/api/users.ts:45-48`
-- **問題**: ユーザー入力を直接SQLクエリに埋め込んでいます
-- **リスク**: データベース全体が侵害される可能性
+#### 1. SQL Injection vulnerability
+- **File**: `src/api/users.ts:45-48`
+- **Problem**: User input directly embedded in SQL query
+- **Risk**: Entire database could be compromised
 - **OWASP**: A03:2021 - Injection
 
-**脆弱なコード:**
+**Vulnerable code:**
 ```typescript
 const query = `SELECT * FROM users WHERE email = '${email}'`;
 db.query(query);
 ```
 
-**修正案:**
+**Fix:**
 ```typescript
 const query = 'SELECT * FROM users WHERE email = ?';
 db.query(query, [email]);
-// または ORMを使用
+// Or use ORM
 const user = await User.findOne({ where: { email } });
 ```
 
-**影響**: 攻撃者が任意のSQLを実行可能
-**修正優先度**: 最高
+**Impact**: Attacker can execute arbitrary SQL
+**Fix priority**: Highest
 
 ---
 
-### ⚠️ High (早急に修正を推奨)
+### High (urgent fix recommended)
 
-#### 2. 認証トークンの不適切な保存
-- **ファイル**: `src/auth/session.ts:23`
-- **問題**: JWTトークンがlocalStorageに保存されています
-- **リスク**: XSS攻撃でトークンが盗まれる可能性
+#### 2. Improper token storage
+- **File**: `src/auth/session.ts:23`
+- **Problem**: JWT token stored in localStorage
+- **Risk**: Token can be stolen via XSS attack
 - **OWASP**: A07:2021 - Identification and Authentication Failures
 
-**脆弱なコード:**
+**Vulnerable code:**
 ```typescript
 localStorage.setItem('authToken', token);
 ```
 
-**修正案:**
+**Fix:**
 ```typescript
-// httpOnly, secure cookieを使用
+// Use httpOnly, secure cookie
 res.cookie('authToken', token, {
   httpOnly: true,
   secure: true,
@@ -210,27 +212,25 @@ res.cookie('authToken', token, {
 
 ---
 
-### 📋 Medium
+### Medium
 
-#### 3. パスワードハッシュの不十分な強度
-- **ファイル**: `src/auth/password.ts:12`
-- **問題**: bcryptのsalt roundsが10未満
-- **推奨**: 12以上のsalt roundsを使用
-
----
-
-### ✅ セキュリティベストプラクティス
-
-検出された良好な実装:
-- ✅ CORS設定が適切に構成されています
-- ✅ CSRFトークン検証が実装されています
-- ✅ HTTPSが強制されています
+#### 3. Insufficient password hash strength
+- **File**: `src/auth/password.ts:12`
+- **Problem**: bcrypt salt rounds below 10
+- **Recommendation**: Use 12+ salt rounds
 
 ---
 
-### 📚 推奨される追加対策
+### Security best practices detected
+- CORS configuration properly set
+- CSRF token validation implemented
+- HTTPS enforced
 
-1. **セキュリティヘッダーの追加**
+---
+
+### Recommended additional measures
+
+1. **Add security headers**
 ```typescript
 app.use(helmet({
   contentSecurityPolicy: true,
@@ -239,7 +239,7 @@ app.use(helmet({
 }));
 ```
 
-2. **レート制限の実装**
+2. **Implement rate limiting**
 ```typescript
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -248,7 +248,7 @@ const limiter = rateLimit({
 app.use('/api/', limiter);
 ```
 
-3. **入力バリデーションライブラリの使用**
+3. **Use input validation library**
 ```typescript
 import { z } from 'zod';
 
@@ -260,15 +260,15 @@ const userSchema = z.object({
 
 ---
 
-### 🔗 参考リソース
+### References
 - [OWASP Top 10 2021](https://owasp.org/Top10/)
 - [CWE/SANS Top 25](https://cwe.mitre.org/top25/)
 - [Node.js Security Best Practices](https://nodejs.org/en/docs/guides/security/)
 
-これらの問題を修正してから進めますか?
+Fix these issues before proceeding?
 ```
 
-## 🛡️ Language-Specific Checks
+## Language-Specific Checks
 
 ### JavaScript/TypeScript
 ```javascript
@@ -315,7 +315,7 @@ const userSchema = z.object({
 - cryptography
 ```
 
-## 🔗 Integration with codex-review
+## Integration with codex-review
 
 Security scan runs automatically during codex-review:
 
@@ -331,7 +331,7 @@ codex-review triggers security-scan when detecting:
 
 **Security findings are included in codex-review output as blocking issues.**
 
-## 🔧 Configuration Parameters
+## Configuration Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -340,7 +340,7 @@ codex-review triggers security-scan when detecting:
 | owasp_checks | all | OWASP categories to check |
 | auto_fix_suggestions | true | Provide code fix examples |
 
-## ⚠️ Important Reminders
+## Important Reminders
 
 1. **Security is non-negotiable** - All Critical/High issues are blocking
 2. **Output in Japanese** for user-facing text
@@ -350,7 +350,7 @@ codex-review triggers security-scan when detecting:
 6. **Check dependencies** for known CVEs
 7. **Fail fast** - Don't allow insecure code to proceed
 
-## 📝 Security Checklist
+## Security Checklist
 
 Before marking code as secure:
 - [ ] All inputs validated and sanitized

--- a/.claude/skills/test-generator/SKILL.md
+++ b/.claude/skills/test-generator/SKILL.md
@@ -6,12 +6,12 @@ description: |
 
 # Test Generator SKILL
 
-## 🎯 Purpose
+## Purpose
 
-**TDD開発の第一歩**: Generate comprehensive test cases before implementation.
+**TDD first step**: Generate comprehensive test cases before implementation.
 Follows Test-Driven Development principles: Red → Green → Refactor.
 
-## 📋 When to Use
+## When to Use
 
 ### Automatic Triggers
 - User mentions "TDD" or "test first"
@@ -22,7 +22,7 @@ Follows Test-Driven Development principles: Red → Green → Refactor.
 - User explicitly asks for test generation
 - During code review if tests are missing
 
-## 🔄 TDD Workflow Integration
+## TDD Workflow Integration
 
 ```
 1. [THIS SKILL] Generate tests (Red phase)
@@ -33,7 +33,7 @@ Follows Test-Driven Development principles: Red → Green → Refactor.
 6. Refactor if needed
 ```
 
-## 🧪 Test Types
+## Test Types
 
 ### 1. Unit Tests
 - Test individual functions/methods in isolation
@@ -58,7 +58,7 @@ Follows Test-Driven Development principles: Red → Green → Refactor.
 - Failure recovery
 - Timeout scenarios
 
-## 📝 Test Generation Process
+## Test Generation Process
 
 ### Step 1: Analyze Target Code
 
@@ -122,7 +122,7 @@ describe('FunctionName', () => {
 **Go:**
 ```go
 func TestFunctionName(t *testing.T) {
-	t.Run("正常系: 有効な入力で正しい結果を返す", func(t *testing.T) {
+	t.Run("normal: returns correct result for valid input", func(t *testing.T) {
 		// Arrange
 		input := Input{ID: 1, Name: "test"}
 
@@ -134,13 +134,13 @@ func TestFunctionName(t *testing.T) {
 		assert.Equal(t, expectedResult, result)
 	})
 
-	t.Run("境界値: 空の入力を処理する", func(t *testing.T) {
+	t.Run("boundary: handles empty input", func(t *testing.T) {
 		result, err := FunctionName(Input{})
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})
 
-	t.Run("異常系: nilを処理する", func(t *testing.T) {
+	t.Run("error: handles nil input", func(t *testing.T) {
 		result, err := FunctionName(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "input cannot be nil")
@@ -152,7 +152,7 @@ func TestFunctionName(t *testing.T) {
 ```python
 class TestFunctionName:
     def test_normal_case_valid_input(self):
-        """正常系: 有効な入力で正しい結果を返す"""
+        """Normal: returns correct result for valid input"""
         # Arrange
         input_data = {"id": 1, "name": "test"}
 
@@ -163,12 +163,12 @@ class TestFunctionName:
         assert result == {"success": True, "data": input_data}
 
     def test_edge_case_empty_input(self):
-        """境界値: 空の入力を処理する"""
+        """Boundary: handles empty input"""
         result = function_name({})
         assert result["success"] is False
 
     def test_error_case_invalid_type(self):
-        """異常系: 不正な型でエラーを発生させる"""
+        """Error: raises error for invalid type"""
         with pytest.raises(TypeError):
             function_name("invalid")
 ```
@@ -201,37 +201,39 @@ jest.mock('../api/userApi', () => ({
 }));
 ```
 
-## 📊 Output Format to User
+## Output Format to User
+
+**All user-facing output must be in Japanese.**
 
 ```markdown
-## テスト生成完了 ✅
+## Test Generation Complete
 
-### 生成したテスト
-- **ファイル**: `tests/user.test.ts`
-- **テストケース数**: 12件
-  - 正常系: 4件
-  - 境界値: 5件
-  - 異常系: 3件
+### Generated Tests
+- **File**: `tests/user.test.ts`
+- **Test cases**: 12
+  - Normal: 4
+  - Boundary: 5
+  - Error: 3
 
-### テストカバレッジ目標
-- 関数カバレッジ: 100%
-- 分岐カバレッジ: 95%+
-- 行カバレッジ: 90%+
+### Coverage Target
+- Function coverage: 100%
+- Branch coverage: 95%+
+- Line coverage: 90%+
 
-### 次のステップ (TDD)
-1. テストを実行: `npm test` または `go test`
-2. **失敗を確認** (Red phase - これが重要!)
-3. 実装を開始
-4. テストが通るまで実装
-5. codex-review で品質チェック
+### Next Steps (TDD)
+1. Run tests: `npm test` or `go test`
+2. **Confirm failures** (Red phase - this is critical!)
+3. Start implementation
+4. Implement until tests pass
+5. Quality check with codex-review
 
-### テストコード
-[生成されたテストコードを表示]
+### Test Code
+[Display generated test code]
 
-このテストでTDDを開始しますか?
+Start TDD with these tests?
 ```
 
-## 🔧 Test Coverage Strategy
+## Test Coverage Strategy
 
 ### Minimum Requirements
 - **All public methods**: 100% coverage
@@ -245,12 +247,11 @@ jest.mock('../api/userApi', () => ({
 - Python: pytest-cov
 - Rust: cargo-tarpaulin
 
-## 🎨 Best Practices
+## Best Practices
 
 ### 1. Test Naming
-- **English for test names**: `test_should_return_error_for_invalid_input`
-- **Japanese for descriptions**: `正常系: 有効な入力で正しい結果を返す`
-- Descriptive and specific
+- Use descriptive, specific names
+- Prefix with category: `normal:`, `boundary:`, `error:`
 - Follow AAA pattern (Arrange-Act-Assert)
 
 ### 2. Test Independence
@@ -269,25 +270,25 @@ jest.mock('../api/userApi', () => ({
 - Don't mock what you own (internal modules)
 - Use real implementations for critical paths
 
-## ⚠️ Common Pitfalls to Avoid
+## Common Pitfalls to Avoid
 
 1. **Testing implementation instead of behavior**
-   - ❌ Test internal function calls
-   - ✅ Test public API behavior
+   - Bad: Test internal function calls
+   - Good: Test public API behavior
 
 2. **Brittle tests**
-   - ❌ Tests break on refactoring
-   - ✅ Tests focus on contract, not implementation
+   - Bad: Tests break on refactoring
+   - Good: Tests focus on contract, not implementation
 
 3. **Incomplete coverage**
-   - ❌ Only testing happy path
-   - ✅ Test edge cases and errors
+   - Bad: Only testing happy path
+   - Good: Test edge cases and errors
 
 4. **Slow tests**
-   - ❌ Real database calls in unit tests
-   - ✅ Mock external dependencies
+   - Bad: Real database calls in unit tests
+   - Good: Mock external dependencies
 
-## 🔗 Integration with Other SKILLs
+## Integration with Other SKILLs
 
 ### With codex-review
 After implementation:
@@ -308,11 +309,11 @@ test-generator generates security tests
   └─ Authorization tests
 ```
 
-## 📌 Important Reminders
+## Important Reminders
 
 1. **Generate tests BEFORE implementation** (TDD principle)
 2. **Confirm tests fail initially** (Red phase)
-3. **Output all descriptions in Japanese** for user
+3. **Output in Japanese** for user-facing text
 4. **Include coverage requirements** in output
 5. **Provide clear next steps** for TDD workflow
 6. **Test behavior, not implementation**

--- a/.claude/skills/web-research/SKILL.md
+++ b/.claude/skills/web-research/SKILL.md
@@ -12,21 +12,21 @@ metadata:
 
 ## Purpose
 
-**外部2者リサーチ**: Geminiが一次調査（Web検索）、Codexが検証。
-Claude Codeは結果のマージと提示のみ行い、コンテキストを消費しない。
+**Dual-source research**: Gemini does primary investigation (web search), Codex cross-verifies.
+Claude Code only merges and presents results — zero context window consumption.
 
 ## When to Use
 
-- ライブラリ・フレームワークの調査
-- API仕様の確認
-- ベストプラクティスの調査
-- エラーの原因調査
-- 技術選定の情報収集
-- 最新バージョン・変更点の確認
+- Library/framework investigation
+- API specification verification
+- Best practices research
+- Error root cause investigation
+- Technology selection research
+- Latest version/changelog verification
 
 ## Research Result Schema
 
-Gemini と Codex は同一のJSONスキーマで結果を返す。
+Gemini and Codex return results in the same JSON schema.
 
 ### Field Definitions
 
@@ -34,12 +34,12 @@ Gemini と Codex は同一のJSONスキーマで結果を返す。
 |-------|------|--------|
 | verification_status | string | `"confirmed"`, `"partially_confirmed"`, `"contradicted"`, `"error"` |
 | freshness | string | `"current"`, `"outdated"`, `"uncertain"` |
-| freshness_detail | string | 自由記述（日本語） |
-| confirmed_facts | string[] | 確認できた事実のリスト |
+| freshness_detail | string | Free-form description (Japanese) |
+| confirmed_facts | string[] | List of confirmed facts |
 | contradictions | object[] | `{claim, correction, source}` |
-| missing_info | string[] | 欠落している重要情報 |
-| additional_findings | string[] | 追加で見つかった情報 |
-| recommended_sources | string[] | 推奨ドキュメントURL |
+| missing_info | string[] | Important missing information |
+| additional_findings | string[] | Additional discovered information |
+| recommended_sources | string[] | Recommended documentation URLs |
 
 ### Example (valid JSON)
 
@@ -47,17 +47,17 @@ Gemini と Codex は同一のJSONスキーマで結果を返す。
 {
   "verification_status": "partially_confirmed",
   "freshness": "current",
-  "freshness_detail": "公式ドキュメントの最新バージョンと一致することを確認",
-  "confirmed_facts": ["React 19がstable版としてリリース済み"],
+  "freshness_detail": "Confirmed match with latest official documentation",
+  "confirmed_facts": ["React 19 released as stable"],
   "contradictions": [
     {
-      "claim": "useEffectは非推奨",
-      "correction": "useEffectは非推奨ではなく、特定ケースでuseを推奨",
+      "claim": "useEffect is deprecated",
+      "correction": "useEffect is not deprecated; use hook is recommended for specific cases",
       "source": "https://react.dev/reference/react/use"
     }
   ],
-  "missing_info": ["Server Componentsに関する記述がない"],
-  "additional_findings": ["React Compilerが実験的に利用可能"],
+  "missing_info": ["No mention of Server Components"],
+  "additional_findings": ["React Compiler experimentally available"],
   "recommended_sources": ["https://react.dev/blog"]
 }
 ```
@@ -68,7 +68,7 @@ Gemini と Codex は同一のJSONスキーマで結果を返す。
 {
   "verification_status": "error",
   "freshness": "uncertain",
-  "freshness_detail": "検証に失敗しました",
+  "freshness_detail": "Verification failed",
   "confirmed_facts": [],
   "contradictions": [],
   "missing_info": [],
@@ -81,14 +81,14 @@ Gemini と Codex は同一のJSONスキーマで結果を返す。
 
 ### Step 1: Gemini Primary Research (Background)
 
-Gemini CLIでWeb検索による一次調査を実行。
-**Claude CodeはWebSearch/WebFetchを使わない。**
+Execute primary investigation via Gemini CLI web search.
+**Claude Code must NOT use WebSearch/WebFetch.**
 
 Launch as background Agent task with Bash:
 
 ```bash
 GEMINI_OUT=$(mktemp "${TMPDIR:-/tmp}/gemini-research.XXXXXX")
-FALLBACK='{"verification_status":"error","freshness":"uncertain","freshness_detail":"Gemini調査に失敗","confirmed_facts":[],"contradictions":[],"missing_info":[],"additional_findings":[],"recommended_sources":[]}'
+FALLBACK='{"verification_status":"error","freshness":"uncertain","freshness_detail":"Gemini research failed","confirmed_facts":[],"contradictions":[],"missing_info":[],"additional_findings":[],"recommended_sources":[]}'
 
 # macOS-compatible timeout (array for zsh compatibility)
 if command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD=(gtimeout 300)
@@ -99,35 +99,35 @@ else TIMEOUT_CMD=(); fi
   -p "$(cat <<PROMPT
 # Web Research: Primary Investigation
 
-すべての出力は日本語で記述してください。
+All output must be in Japanese.
 
-重要: あなたはGemini CLIとして実行されています。Web検索はデフォルトで有効です。
-必ず独自にWeb検索を行い最新情報を取得してください。
+Important: You are running as Gemini CLI. Web search is enabled by default.
+You MUST perform independent web searches to get the latest information.
 
-## 調査トピック
-[ユーザーのリサーチクエリをここに挿入]
+## Research Topic
+[Insert user's research query here]
 
-## あなたのタスク
+## Your Task
 
-1. 上記トピックについて、Web検索で最新の公式情報を収集してください
-2. 以下を重点的に調査:
-   - 最新バージョン・リリース情報
-   - 公式ドキュメントURL
-   - ベストプラクティス・推奨パターン
-   - deprecatedな機能・破壊的変更
-3. 情報の鮮度（いつの情報か）を明記してください
+1. Collect the latest official information via web search on the above topic
+2. Focus on:
+   - Latest version/release information
+   - Official documentation URLs
+   - Best practices/recommended patterns
+   - Deprecated features/breaking changes
+3. Note the freshness of information (when it was published)
 
-以下のJSON形式で正確に出力してください（コードブロックなし、JSONのみ）。
+Output exactly in the following JSON format (no code blocks, JSON only).
 
 ## Example Output
 {
   "verification_status": "confirmed",
   "freshness": "current",
-  "freshness_detail": "2026年3月時点の最新情報と一致",
-  "confirmed_facts": ["事実1", "事実2"],
+  "freshness_detail": "Matches latest information as of March 2026",
+  "confirmed_facts": ["Fact 1", "Fact 2"],
   "contradictions": [],
   "missing_info": [],
-  "additional_findings": ["Web検索で見つかった追加情報"],
+  "additional_findings": ["Additional info from web search"],
   "recommended_sources": ["https://example.com/docs"]
 }
 PROMPT
@@ -146,7 +146,7 @@ fi
 PARSED=$(python3 -c "
 import json, sys, re
 
-FALLBACK = '{\"verification_status\":\"error\",\"freshness\":\"uncertain\",\"freshness_detail\":\"Gemini出力のパース失敗\",\"confirmed_facts\":[],\"contradictions\":[],\"missing_info\":[],\"additional_findings\":[],\"recommended_sources\":[]}'
+FALLBACK = '{\"verification_status\":\"error\",\"freshness\":\"uncertain\",\"freshness_detail\":\"Failed to parse Gemini output\",\"confirmed_facts\":[],\"contradictions\":[],\"missing_info\":[],\"additional_findings\":[],\"recommended_sources\":[]}'
 
 try:
     data = json.load(open('$GEMINI_OUT'))
@@ -189,16 +189,16 @@ rm -f "$GEMINI_OUT"
 
 ### Step 2: Codex Cross-Verification (Background)
 
-Geminiの調査結果を受け取り、Codexが独立に検証。
-**Step 1と並列実行。Geminiの結果が先に返った場合、その内容をCodexに渡す。**
-**Geminiがまだ返っていない場合は、トピックのみでCodexに独自調査させる。**
+Receives Gemini's results and independently verifies.
+**Runs in parallel with Step 1. If Gemini returns first, pass its results to Codex.**
+**If Gemini hasn't returned yet, have Codex investigate independently with topic only.**
 
 Launch as background Agent task with Bash:
 
 ```bash
 ROOT=$(git rev-parse --show-toplevel)
 CODEX_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-research.XXXXXX")
-FALLBACK='{"verification_status":"error","freshness":"uncertain","freshness_detail":"Codex検証に失敗","confirmed_facts":[],"contradictions":[],"missing_info":[],"additional_findings":[],"recommended_sources":[]}'
+FALLBACK='{"verification_status":"error","freshness":"uncertain","freshness_detail":"Codex verification failed","confirmed_facts":[],"contradictions":[],"missing_info":[],"additional_findings":[],"recommended_sources":[]}'
 
 # macOS-compatible timeout (array for zsh compatibility)
 if command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD=(gtimeout 300)
@@ -211,23 +211,23 @@ else TIMEOUT_CMD=(); fi
   "$(cat <<PROMPT
 # Web Research Cross-Verification
 
-すべての出力は日本語で記述してください。
+All output must be in Japanese.
 
-## 調査トピック
-[ユーザーのリサーチクエリをここに挿入]
+## Research Topic
+[Insert user's research query here]
 
-## Geminiの調査結果（利用可能な場合）
-[Geminiの結果をここに挿入。まだ返っていない場合は「Gemini結果なし - 独自に調査してください」]
+## Gemini's Research Results (if available)
+[Insert Gemini results here. If not yet returned: "Gemini results unavailable - investigate independently"]
 
-## あなたのタスク
+## Your Task
 
-1. 上記トピックについて、あなた自身の知識で独立に検証してください
-2. Geminiの調査結果がある場合は、その正確性を検証してください
-3. 以下の観点でチェックしてください:
-   - 情報は最新か？（古い情報やdeprecatedな内容が含まれていないか）
-   - 事実関係は正確か？
-   - 重要な情報の欠落はないか？
-   - より良い代替案やアプローチはないか？
+1. Independently verify the above topic using your own knowledge
+2. If Gemini results are available, verify their accuracy
+3. Check from the following perspectives:
+   - Is the information current? (Any outdated or deprecated content?)
+   - Are the facts accurate?
+   - Is important information missing?
+   - Are there better alternatives or approaches?
 PROMPT
 )"
 
@@ -247,16 +247,16 @@ rm -f "$CODEX_OUT"
 
 ### Step 3: Merge & Analyze Results
 
-Gemini/Codexの結果を統合して信頼度を判定。
-**Claude Codeはここで初めて結果を受け取る（要約のみ）。**
+Merge Gemini/Codex results and determine confidence level.
+**Claude Code receives results here for the first time (summary only).**
 
 ```python
 def normalize_result(result):
-    """None、error、不完全なJSONを安全なデフォルトに正規化。"""
+    """Normalize None, error, or incomplete JSON to safe defaults."""
     FALLBACK = {
         "verification_status": "error",
         "freshness": "uncertain",
-        "freshness_detail": "結果を取得できませんでした",
+        "freshness_detail": "Failed to retrieve results",
         "confirmed_facts": [],
         "contradictions": [],
         "missing_info": [],
@@ -309,7 +309,7 @@ def normalize_result(result):
 
 
 def merge_research(gemini_result, codex_result):
-    """Gemini(一次調査)/Codex(検証)の結果をマージし、信頼度を判定する。"""
+    """Merge Gemini (primary) and Codex (verification) results, determine confidence."""
     gemini = normalize_result(gemini_result)
     codex = normalize_result(codex_result)
 
@@ -362,72 +362,74 @@ def merge_research(gemini_result, codex_result):
 
 ## Output Format
 
+**All user-facing output must be in Japanese.**
+
 ```markdown
-## 調査結果: [トピック]
+## Research Results: [Topic]
 
-### 信頼度判定
-- **総合信頼度**: 高（2者確認済） / 中（1者確認 or 部分一致） / 低（矛盾あり） / 未検証（外部調査失敗）
-- **検証ソース数**: N/2
-- **情報鮮度**: 最新 / 古い可能性あり / 不明
+### Confidence Assessment
+- **Overall confidence**: High (2 sources confirmed) / Medium (1 source or partial match) / Low (contradictions) / Unverified (external research failed)
+- **Verification sources**: N/2
+- **Information freshness**: Current / Potentially outdated / Unknown
 
-### 主要な調査結果（Gemini Web検索）
-[Geminiの一次調査結果]
+### Primary Research Results (Gemini Web Search)
+[Gemini's primary research results]
 
-### クロスチェック結果（Codex検証）
+### Cross-check Results (Codex Verification)
 
-#### 一致した情報（信頼度: 高）
-- [両者が一致した事実]
+#### Agreed Information (high confidence)
+- [Facts both sources agree on]
 
-#### 追加情報
-- **Gemini追加**: [Geminiのみが見つけた情報（Web検索ベース）]
-- **Codex追加**: [Codexのみが指摘した情報]
+#### Additional Information
+- **Gemini additional**: [Information only Gemini found (web search based)]
+- **Codex additional**: [Information only Codex noted]
 
-#### 矛盾・相違点（要注意）
-| 項目 | Gemini | Codex |
+#### Contradictions (attention required)
+| Item | Gemini | Codex |
 |------|--------|-------|
-| [項目] | [主張] | [主張] |
+| [Item] | [Claim] | [Claim] |
 
-#### 情報鮮度チェック
-- **Gemini判定**: [詳細]
-- **Codex判定**: [詳細]
+#### Freshness Check
+- **Gemini assessment**: [Detail]
+- **Codex assessment**: [Detail]
 
-### 推奨ドキュメント
+### Recommended Documentation
 - [URL1] (source: Gemini/Codex)
 - [URL2] (source: Gemini/Codex)
 
-### 注意事項
-- [矛盾がある場合の注意点]
-- [情報が古い可能性がある項目]
+### Notes
+- [Notes about contradictions if any]
+- [Items that may be outdated]
 ```
 
 ## Error Handling
 
-**全てのエラーケースでフォールバックJSONを返す。**
+**All error cases return fallback JSON.**
 
-### 2者成功 (Both Gemini and Codex)
-- 通常のマージ処理、信頼度は一致度に基づいて判定
+### Both Succeed (Gemini and Codex)
+- Normal merge processing, confidence based on agreement level
 
-### 1者成功 (Gemini or Codex片方のみ)
-- 成功したソースの結果を採用
-- 信頼度を「中」に設定
-- 失敗したソースを明記
+### One Succeeds (Gemini or Codex only)
+- Use successful source's results
+- Set confidence to "medium"
+- Note which source failed
 
-### 0者成功 (Both failed)
-- 信頼度を「未検証」と明記
-- ユーザーに手動確認を推奨: `⚠️ 外部調査に失敗しました。手動での確認を推奨します`
+### Both Fail
+- Set confidence to "unverified"
+- Recommend manual verification: `Warning: External research failed. Manual verification recommended.`
 
 ## Integration with latest-docs
 
-`latest-docs` スキルから呼び出される場合:
-- Geminiの検索クエリにバージョン・deprecation関連を追加
-- 結果を `latest-docs` のフォーマットに合わせて返却
+When called from `latest-docs` skill:
+- Add version/deprecation keywords to Gemini search query
+- Return results in `latest-docs` format
 
 ## Important Reminders
 
-1. **Claude CodeはWebSearch/WebFetchを使わない** - 全てGemini+Codexに委譲
-2. **並列実行**: Gemini と Codex は必ずバックグラウンドで並列実行
-3. **Gemini = 一次調査**: Web検索で最新情報を取得
-4. **Codex = 検証**: Geminiの結果を知識ベースで検証
-5. **矛盾は隠さない**: 結果が矛盾する場合、すべて提示してユーザーに判断を委ねる
-6. **フォールバック保証**: 全エラーケースで有効なJSONを返す
-7. **日本語出力**: すべてのユーザー向けテキストは日本語
+1. **Claude Code must NOT use WebSearch/WebFetch** - Delegate everything to Gemini+Codex
+2. **Parallel execution**: Always run Gemini and Codex in background in parallel
+3. **Gemini = primary research**: Get latest information via web search
+4. **Codex = verification**: Verify Gemini's results with knowledge base
+5. **Don't hide contradictions**: Present all contradictions for user to judge
+6. **Fallback guarantee**: All error cases return valid JSON
+7. **Output in Japanese**: All user-facing text in Japanese


### PR DESCRIPTION
## 概要

全SKILL.mdファイルの言語を英語に統一。日本語が混在していた8ファイルを整理。

## 変更点

- codex-design, codex-review, gemini-review, quality-gate, web-research, security-scan, test-generator, difit の SKILL.md を英語に統一
- Codex/Geminiへのプロンプト内の日本語指示を英語化（`"All output must be in Japanese"` の指示は維持）
- ユーザー向け出力テンプレート内の日本語ラベルを英語化
- Go/Pythonテストの日本語テスト名を英語に変更（`正常系:` → `normal:` 等）
- 出力フォーマットのセクションヘッダーを英語化

## テスト

- SKILL.mdは設定/ドキュメントファイルのため構文テスト不要
- 機能的な変更なし（言語のみの変更）

## 注意点

- `"Output in Japanese"` / `"All output must be in Japanese"` の指示は全ファイルで維持
- delegation rules (`language.md`) の「Codex/Gemini には英語プロンプト」ポリシーと整合

🤖 Generated with [Claude Code](https://claude.com/claude-code)