### PR TITLE
feat: add Parsec support and optimize zsh startup

### DIFF
--- a/.config/gokurakujoudo/karabiner.edn
+++ b/.config/gokurakujoudo/karabiner.edn
@@ -19,7 +19,7 @@
     :moonlander [{:vendor_id 12951 :product_id 6505}]
   }
 
-  :applications {:chrome ["^com\\.google\\.Chrome$"] :alacritty ["^io\\.alacritty$", "^org\\.alacritty$"] :ghostty ["^com\\.mitchellh\\.ghostty$"] :cmux ["^com\\.cmuxterm\\.app$"] :vscode ["^com\\.microsoft\\.VSCode$"] :cursor ["^com\\.todesktop\\.230313mzl4w4u92$"]}
+  :applications {:chrome ["^com\\.google\\.Chrome$"] :alacritty ["^io\\.alacritty$", "^org\\.alacritty$"] :ghostty ["^com\\.mitchellh\\.ghostty$"] :cmux ["^com\\.cmuxterm\\.app$"] :vscode ["^com\\.microsoft\\.VSCode$"] :cursor ["^com\\.todesktop\\.230313mzl4w4u92$"] :parsec ["^tv\\.parsec\\.www$"]}
 
   :main [
     {:des "Change right_command to command+control+option+shift"
@@ -27,9 +27,9 @@
       [:right_command :!QWEright_shift :macbook]
     ]}
 
-    {:des "Change caps_lock to control+option+shift"
+    {:des "Change caps_lock to control+option+shift (alone: toggle input source via ctrl+space)"
     :rules [
-      [:caps_lock :!TOleft_shift :macbook]
+      [:caps_lock :!TOleft_shift :macbook {:alone :!Tspacebar}]
     ]}
 
     {:des "Chrome move tab key bind"
@@ -38,7 +38,7 @@
       [:!TOSleft_arrow :!TStab :chrome]
     ]}
 
-    {:des "Chrome, Visual Studio Code, Cursor, alacritty, ghostty delete tab key bind"
+    {:des "Chrome, Visual Studio Code, Cursor, alacritty, ghostty, cmux delete tab key bind"
     :rules [
       [:!TOSw :!Cw :chrome]
       [:!TOSw :!Cw :vscode]
@@ -46,6 +46,7 @@
       [:!TOSw :!Cw :alacritty]
       [:!TOSw :!Cw :ghostty]
       [:!TOSw :!Cw :cmux]
+      [:!TOSw :!Cw :parsec]
     ]}
 
     {:des "Visual Studio Code, Cursor file move key bind"
@@ -96,5 +97,20 @@
       [:!TOSleft_arrow :!TStab :ghostty]
       [:!TOSright_arrow :!Ttab :cmux]
       [:!TOSleft_arrow :!TStab :cmux]
+    ]}
+
+    {:des "Parsec: cmux key binds (transform locally before sending to remote)"
+    :rules [
+      ;; tab move
+      [:!TOSright_arrow :!Ttab :parsec]
+      [:!TOSleft_arrow :!TStab :parsec]
+      ;; pane move
+      [:!Sleft_arrow :!COleft_arrow :parsec]
+      [:!Rleft_arrow :!COleft_arrow :parsec]
+      [:!Sright_arrow :!COright_arrow :parsec]
+      [:!Rright_arrow :!COright_arrow :parsec]
+      ;; workspace move
+      [:!TOSup_arrow :!TCopen_bracket :parsec]
+      [:!TOSdown_arrow :!TCclose_bracket :parsec]
     ]}
 ]}

--- a/.skhdrc
+++ b/.skhdrc
@@ -35,8 +35,10 @@ meh - e : yabai -m window --toggle split
 # alt - t : yabai -m window --toggle float && /tmp/yabai-restore/$(yabai -m query --windows --window | jq -re '.id').restore 2>/dev/null || true
 meh - t : yabai -m window --toggle float && yabai -m window --grid 4:4:1:1:2:2
 
-# cmux (ghostty-based terminal)
-meh - return : osascript -e 'tell application "cmux" to run' \
+# cmux (ghostty-based terminal) - skip when Parsec is frontmost
+meh - return : frontapp=$(osascript -e 'tell application "System Events" to get bundle identifier of first application process whose frontmost is true' 2>/dev/null); \
+  [ "$frontapp" = "tv.parsec.www" ] && exit 0; \
+  osascript -e 'tell application "cmux" to run' \
   -e 'tell application "System Events"' \
   -e 'if application process "cmux" exists then' \
   -e 'if frontmost of application process "cmux" is true then' \

--- a/.zsh/init.zsh
+++ b/.zsh/init.zsh
@@ -8,20 +8,21 @@ export STARSHIP_CONFIG="$HOME/.config/starship/starship.toml"
 
 ZSH_AUTOSUGGEST_HIGHLIGHT_STYLE='fg=#00ff00'
 
+## Cache brew prefix (avoid calling brew --prefix 3 times = ~1s overhead)
+_brew_prefix="/opt/homebrew"
+
 ## syntax-highlighting
-source "$(brew --prefix)/share/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" 2>/dev/null || \
+source "${_brew_prefix}/share/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" 2>/dev/null || \
   source ~/Git-Project/github.com/zdharma-continuum/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh
 
 ## zsh-completions and autosuggestions
-if type brew &>/dev/null; then
-  FPATH="$(brew --prefix)/share/zsh-completions:$FPATH"
-  source "$(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
-fi
+FPATH="${_brew_prefix}/share/zsh-completions:$FPATH"
+source "${_brew_prefix}/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 autoload -Uz compinit
-compinit -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump-$ZSH_VERSION-$HOST"
+compinit -i -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump-$ZSH_VERSION-$HOST"
 
 ## docker desktop
-source /Users/takumiakasaka/.docker/init-zsh.sh || true
+[ -f /Users/takumiakasaka/.docker/init-zsh.sh ] && source /Users/takumiakasaka/.docker/init-zsh.sh
 
 ## starship
 eval "$(starship init zsh)"


### PR DESCRIPTION
## 概要
Parsec リモートデスクトップ使用時のキーバインド対応と、zsh 起動速度の最適化。

## 変更点
- **zsh 起動高速化**: `brew --prefix` を3回呼び出していたのを変数キャッシュに変更（約1秒短縮）
- **Karabiner Parsec 対応**: Parsec アクティブ時にローカルで cmux キー変換を行い、リモートに正しいキーを送信
- **Caps Lock 単押し**: 入力ソース切り替え（Ctrl+Space）を追加（長押しは従来通り Ctrl+Opt+Shift）
- **skhd Parsec 除外**: Parsec フォーカス時に cmux トグルをスキップ

## テスト
- `time zsh -i -c exit` で起動時間短縮を確認
- Parsec 経由で cmux タブ移動・ペイン移動・ワークスペース移動が動作することを確認
- Parsec 使用中に skhd の cmux トグルがローカルで発火しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)