### PR TITLE
feat: add Firefox keybindings to match Chrome

### DIFF
--- a/.config/gokurakujoudo/karabiner.edn
+++ b/.config/gokurakujoudo/karabiner.edn
@@ -19,7 +19,7 @@
     :moonlander [{:vendor_id 12951 :product_id 6505}]
   }
 
-  :applications {:chrome ["^com\\.google\\.Chrome$"] :alacritty ["^io\\.alacritty$", "^org\\.alacritty$"] :ghostty ["^com\\.mitchellh\\.ghostty$"] :vscode ["^com\\.microsoft\\.VSCode$"] :cursor ["^com\\.todesktop\\.230313mzl4w4u92$"] :parsec ["^tv\\.parsec\\.www$"]}
+  :applications {:chrome ["^com\\.google\\.Chrome$"] :firefox ["^org\\.mozilla\\.firefox$"] :alacritty ["^io\\.alacritty$", "^org\\.alacritty$"] :ghostty ["^com\\.mitchellh\\.ghostty$"] :vscode ["^com\\.microsoft\\.VSCode$"] :cursor ["^com\\.todesktop\\.230313mzl4w4u92$"] :parsec ["^tv\\.parsec\\.www$"]}
 
   :main [
     {:des "Change right_command to command+control+option+shift"
@@ -32,15 +32,18 @@
       [:caps_lock :!TOleft_shift :macbook {:alone :!Tspacebar}]
     ]}
 
-    {:des "Chrome move tab key bind"
+    {:des "Chrome, Firefox move tab key bind"
     :rules [
       [:!TOSright_arrow :!Ttab :chrome]
       [:!TOSleft_arrow :!TStab :chrome]
+      [:!TOSright_arrow :!Ttab :firefox]
+      [:!TOSleft_arrow :!TStab :firefox]
     ]}
 
-    {:des "Chrome, Visual Studio Code, Cursor, alacritty, ghostty delete tab key bind"
+    {:des "Chrome, Firefox, Visual Studio Code, Cursor, alacritty, ghostty delete tab key bind"
     :rules [
       [:!TOSw :!Cw :chrome]
+      [:!TOSw :!Cw :firefox]
       [:!TOSw :!Cw :vscode]
       [:!TOSw :!Cw :cursor]
       [:!TOSw :!Cw :alacritty]


### PR DESCRIPTION
## 概要
FirefoxにChromeと同じキーバインドをKarabiner（GokuRakuJoudo）で設定

## 変更点
- Firefoxアプリケーション定義を追加（`org.mozilla.firefox`）
- タブ移動キーバインド（`Ctrl+Option+Shift+→/←`）をFirefoxに追加
- タブ閉じるキーバインド（`Ctrl+Option+Shift+W`）をFirefoxに追加

## テスト
- `goku` コマンドで設定反映済み
- Codex Review: OK（ブロッキング問題なし、Bundle ID検証済み）
- Gemini Review: OK（安全に適用可能）

## 注意点
- Firefox Developer EditionやNightlyはBundle IDが異なるため、必要に応じて別途追加が必要

issue: #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)