### PR TITLE
fix(codex-review): prevent stdin hang & signal exit bug

### DIFF
--- a/.claude/skills/codex-design/SKILL.md
+++ b/.claude/skills/codex-design/SKILL.md
@@ -67,10 +67,27 @@ Claude Code proposes 2-3 viable approaches:
 
 ### Step 3: Codex Consultation
 
-Execute Codex in read-only sandbox for design review:
+Execute Codex in read-only sandbox for design review.
+
+> **Invariants — see codex-review/SKILL.md Step 2 for full rationale:**
+> 1. **`< /dev/null`** — `codex exec` probes stdin even when prompt is passed as an argument;
+>    inherited open pipes from Claude Code's Bash will hang the call indefinitely.
+> 2. **Portable timeout** — macOS has no `timeout` by default; use the TIMEOUT_CMD fallback chain.
+> 3. **`--ephemeral`** — avoids session-file contention in parallel runs.
 
 ```bash
-codex exec --model gpt-5.4 --sandbox read-only "$(cat <<'EOF'
+# Portable timeout (gtimeout → timeout → perl alarm → none).
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 1200)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 1200)
+elif command -v perl >/dev/null 2>&1; then
+  TIMEOUT_CMD=(perl -e 'my $t=shift; my $pid=fork; if(!defined $pid){die "fork: $!"} if($pid==0){exec @ARGV; exit 127} $SIG{ALRM}=sub{kill "TERM",$pid; sleep 2; kill "KILL",$pid; exit 124}; alarm $t; waitpid $pid,0; my $st=$?; exit($st & 127 ? 128 + ($st & 127) : $st >> 8)' 1200)
+else
+  TIMEOUT_CMD=()
+fi
+
+"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral "$(cat <<'EOF'
 # Design Consultation Request
 
 All string fields (reasoning, risks, recommendations, guidance) must be in Japanese.
@@ -160,7 +177,7 @@ All string fields (reasoning, risks, recommendations, guidance) must be in Japan
   "caveats": ["Caveat 1", "Caveat 2"]
 }
 EOF
-)"
+)" < /dev/null
 ```
 
 ### Step 4: Analysis and Synthesis

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -36,11 +36,32 @@ git diff HEAD --name-status --find-renames
 
 **Critical: Codex runs in read-only sandbox for safety**
 
+> **Three invariants — violate any of these and the run hangs or silently fails:**
+> 1. **Redirect stdin from `/dev/null`** (`< /dev/null`). `codex exec` always probes stdin
+>    (you'll see `Reading additional input from stdin...` in output) and will block on the pipe
+>    EOF inherited from Claude Code's Bash/Subagent execution. Without this redirect, the call
+>    hangs indefinitely — this is the #1 cause of "codex CLI hangs on stdin" failures.
+> 2. **Wrap with a portable timeout.** macOS has no `timeout` by default — use the `TIMEOUT_CMD`
+>    array below, which falls back through `gtimeout` → `timeout` → `perl alarm` shim.
+> 3. **Pass `--ephemeral`** to avoid `~/.codex/history.jsonl` / session-file contention when
+>    running in parallel with other codex invocations (quality-gate's codex+gemini fan-out).
+
 ```bash
 ROOT=$(git rev-parse --show-toplevel)
 REVIEW_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-review.XXXXXX")
 
-codex exec --model gpt-5.4 --sandbox read-only \
+# Portable timeout (zsh-safe array form). Falls back to perl alarm shim on macOS.
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 1200)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 1200)
+elif command -v perl >/dev/null 2>&1; then
+  TIMEOUT_CMD=(perl -e 'my $t=shift; my $pid=fork; if(!defined $pid){die "fork: $!"} if($pid==0){exec @ARGV; exit 127} $SIG{ALRM}=sub{kill "TERM",$pid; sleep 2; kill "KILL",$pid; exit 124}; alarm $t; waitpid $pid,0; my $st=$?; exit($st & 127 ? 128 + ($st & 127) : $st >> 8)' 1200)
+else
+  TIMEOUT_CMD=()
+fi
+
+"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
   --output-schema "$ROOT/.claude/skills/codex-review/review-schema.json" \
   -o "$REVIEW_OUT" \
   "$(cat <<'EOF'
@@ -76,12 +97,18 @@ All string fields (summary, problem, recommendation, notes_for_next_review) must
 - testing: Missing tests, inadequate coverage
 - style: Code style, naming conventions (usually advisory)
 EOF
-)"
+)" < /dev/null
+CODEX_EXIT=$?
 
-# Verify result (fail-closed on error)
-if [ $? -ne 0 ] || [ ! -s "$REVIEW_OUT" ]; then
+# Verify result (fail-closed on error). Exit 124 = timeout from gtimeout/timeout/perl shim.
+if [ "$CODEX_EXIT" -eq 124 ]; then
   rm -f "$REVIEW_OUT"
-  echo "ERROR: codex exec failed or produced empty output" >&2
+  echo "ERROR: codex exec timed out after 1200s — split files and retry" >&2
+  exit 124
+fi
+if [ "$CODEX_EXIT" -ne 0 ] || [ ! -s "$REVIEW_OUT" ]; then
+  rm -f "$REVIEW_OUT"
+  echo "ERROR: codex exec failed (exit=$CODEX_EXIT) or produced empty output" >&2
   exit 1
 fi
 
@@ -398,7 +425,19 @@ When triggered from **ExitPlanMode** (via quality-gate Step 1), Codex reviews th
 ROOT=$(git rev-parse --show-toplevel)
 PLAN_REVIEW_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-plan-review.XXXXXX")
 
-codex exec --model gpt-5.4 --sandbox read-only \
+# Portable timeout (see Step 2 invariants — `< /dev/null`, `--ephemeral`, and TIMEOUT_CMD
+# are all required to prevent stdin hangs and session-file contention).
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 1200)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 1200)
+elif command -v perl >/dev/null 2>&1; then
+  TIMEOUT_CMD=(perl -e 'my $t=shift; my $pid=fork; if(!defined $pid){die "fork: $!"} if($pid==0){exec @ARGV; exit 127} $SIG{ALRM}=sub{kill "TERM",$pid; sleep 2; kill "KILL",$pid; exit 124}; alarm $t; waitpid $pid,0; my $st=$?; exit($st & 127 ? 128 + ($st & 127) : $st >> 8)' 1200)
+else
+  TIMEOUT_CMD=()
+fi
+
+"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
   --output-schema "$ROOT/.claude/skills/codex-review/plan-review-schema.json" \
   -o "$PLAN_REVIEW_OUT" \
   "$(cat <<'EOF'
@@ -421,12 +460,18 @@ All string fields (summary, section, problem, recommendation, suggestions) must 
 - **blocking**: Fatal issue in plan. Fix required → ok: false
 - **advisory**: Improvement recommended but plan can proceed
 EOF
-)"
+)" < /dev/null
+CODEX_EXIT=$?
 
-# Verify result (fail-closed on error)
-if [ $? -ne 0 ] || [ ! -s "$PLAN_REVIEW_OUT" ]; then
+# Verify result (fail-closed on error). Exit 124 = timeout.
+if [ "$CODEX_EXIT" -eq 124 ]; then
   rm -f "$PLAN_REVIEW_OUT"
-  echo "ERROR: codex exec failed or produced empty output" >&2
+  echo "ERROR: codex plan-review timed out after 1200s" >&2
+  exit 124
+fi
+if [ "$CODEX_EXIT" -ne 0 ] || [ ! -s "$PLAN_REVIEW_OUT" ]; then
+  rm -f "$PLAN_REVIEW_OUT"
+  echo "ERROR: codex exec failed (exit=$CODEX_EXIT) or produced empty output" >&2
   exit 1
 fi
 

--- a/.claude/skills/web-research/SKILL.md
+++ b/.claude/skills/web-research/SKILL.md
@@ -200,12 +200,22 @@ ROOT=$(git rev-parse --show-toplevel)
 CODEX_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-research.XXXXXX")
 FALLBACK='{"verification_status":"error","freshness":"uncertain","freshness_detail":"Codex verification failed","confirmed_facts":[],"contradictions":[],"missing_info":[],"additional_findings":[],"recommended_sources":[]}'
 
-# macOS-compatible timeout (array for zsh compatibility)
-if command -v gtimeout >/dev/null 2>&1; then TIMEOUT_CMD=(gtimeout 300)
-elif command -v timeout >/dev/null 2>&1; then TIMEOUT_CMD=(timeout 300)
-else TIMEOUT_CMD=(); fi
+# macOS-compatible timeout (array for zsh compatibility).
+# `perl alarm` shim ensures a hard cap even when coreutils is not installed.
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 300)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 300)
+elif command -v perl >/dev/null 2>&1; then
+  TIMEOUT_CMD=(perl -e 'my $t=shift; my $pid=fork; if(!defined $pid){die "fork: $!"} if($pid==0){exec @ARGV; exit 127} $SIG{ALRM}=sub{kill "TERM",$pid; sleep 2; kill "KILL",$pid; exit 124}; alarm $t; waitpid $pid,0; my $st=$?; exit($st & 127 ? 128 + ($st & 127) : $st >> 8)' 300)
+else
+  TIMEOUT_CMD=()
+fi
 
-"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only \
+# `< /dev/null` and `--ephemeral` are mandatory:
+# - codex exec probes stdin even when prompt is passed as arg → would hang on inherited pipes
+# - --ephemeral avoids ~/.codex/history.jsonl contention with parallel codex invocations
+"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
   --output-schema "$ROOT/.claude/skills/web-research/verification-schema.json" \
   -o "$CODEX_OUT" \
   "$(cat <<PROMPT
@@ -229,7 +239,7 @@ All output must be in Japanese.
    - Is important information missing?
    - Are there better alternatives or approaches?
 PROMPT
-)"
+)" < /dev/null
 
 EXIT_CODE=$?
 


### PR DESCRIPTION
## 概要

`codex-review` skill が頻繁に「Codex CLI が stdin で hang」して失敗する問題を修正。

## 根本原因

`codex exec` は prompt を引数で渡しても**必ず stdin を probe する仕様** (`Reading additional input from stdin...` を出力)。Claude Code の Bash / Subagent 経由で起動するとパイプ EOF を待ち続けてハングする。

- `codex-review/SKILL.md` には `< /dev/null` も timeout ラッパーも無く、無限待機 → 失敗扱い
- Gemini が通っていたのは `gemini -p` が stdin を読まず、既に timeout ラッパー付きだったため

## 変更点

3 ファイルの `codex exec` 呼び出し全 4 箇所に以下を適用:

1. **`< /dev/null`** — stdin を即 EOF にしてハングを根絶
2. **portable timeout ラッパー** — `gtimeout` → `timeout` → `perl alarm シム` → なし の順でフォールバック
3. **`--ephemeral`** — 並列実行時の `~/.codex/history.jsonl` 競合を回避
4. **`exit code 124` 判別** — timeout 専用エラーメッセージへ分岐

### Perl alarm シムの 2 段階修正

初版の `exit($?>>8)` には **signal 終了を 0 (成功) として誤伝播するバグ**があり、Codex レビューで実機再現された (`sh -c 'kill -TERM \$\$'` で wrapper が EXIT:0)。`my \$st=\$?; exit(\$st & 127 ? 128 + (\$st & 127) : \$st >> 8)` に修正し、SIGTERM/SIGKILL は 128+signal、通常終了は \$st>>8 を返すよう改善。

## テスト

### Perl alarm シムの単体検証

| ケース | 期待 | 実測 |
|---|---|---|
| 通常 exit 7 | 7 | 7 ✓ |
| SIGTERM | 143 | 143 ✓ |
| SIGKILL | 137 | 137 ✓ |
| timeout 1s / sleep 5 | 124 | 124 ✓ |
| 通常 exit 0 | 0 | 0 ✓ |

### End-to-end smoke test

修正版 `codex-review` パターンで実際に `codex exec` を起動し、JSON 出力・exit code 0・ハング無しを確認。

### 自己レビュー (quality-gate)

修正版の `codex-review` skill 自身に本 PR の差分をレビューさせ、iteration 2 で `ok: true` を取得。Gemini-review も並列で実行し、同じ blocking 問題 (perl 終了コード伝播) を検出 → 修正後に解消を確認。

## 注意点

- 残る advisory: 同じ TIMEOUT_CMD / perl shim が 4 箇所コピペになっている (将来の保守ドリフトリスク)。本 PR のスコープ外。共通スクリプト化は別タスクで対応可能。
- `--ephemeral` により codex のセッション履歴が `~/.codex/` に残らなくなる (CI/並列用途では問題なし、対話的に resume したい場合は要検討)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)