### PR TITLE
docs: add Moonlander layout README

### DIFF
--- a/.moonland/README.md
+++ b/.moonland/README.md
@@ -1,0 +1,10 @@
+# Moonlander Layout
+
+ZSA Oryx configurator:
+https://configure.zsa.io/moonlander/layouts/9pjr7/latest/0
+
+## Layers
+
+- ![Layer 0](Layer0.png)
+- ![Layer 1](Layer1.png)
+- ![Layer 2](Layer2.png)


### PR DESCRIPTION
## 概要
`.moonland/` ディレクトリに README を追加。ZSA Oryx configurator の URL と既存のレイヤー画像 (Layer0/1/2.png) へのリンクをまとめた。

## 変更点
- `.moonland/README.md` を新規作成
  - Oryx configurator URL: https://configure.zsa.io/moonlander/layouts/9pjr7/latest/0
  - 既存の Layer0.png / Layer1.png / Layer2.png への画像リンク

## テスト
- Markdown のレンダリングを目視確認（URL リンクと画像参照が正しい形式）

## 注意点
- ドキュメント追加のみ。コード変更・設定変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)