### PR TITLE
feat: add Superset notification hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -121,6 +121,15 @@
             "command": "jq -r '.tool_input.file_path | select(endswith(\".tf\") or endswith(\".tfvars\"))' | xargs -r -I {} sh -c 'command -v terraform >/dev/null && terraform fmt \"$1\"' _ {}"
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
       }
     ],
     "Notification": [
@@ -130,6 +139,68 @@
           {
             "type": "command",
             "command": "osascript -e 'display notification \"Task completed\" with title \"Claude Code\"' && afplay /System/Library/Sounds/Glass.aiff"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/notify.sh\" ] && SUPERSET_AGENT_ID=claude \"$SUPERSET_HOME_DIR/hooks/notify.sh\" || true"
           }
         ]
       }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -50,5 +50,57 @@
   },
   "agents": {
     "overrides": {}
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" ] && \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" ] && \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "BeforeAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" ] && \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" ] && \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" || true"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$SUPERSET_HOME_DIR\" ] && [ -x \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" ] && \"$SUPERSET_HOME_DIR/hooks/gemini-hook.sh\" || true"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@
 .claude/plugins/known_marketplaces.json
 .claude/plugins/marketplaces/
 
+# Codex-managed system skills (auto-installed)
+.claude/skills/.system/
+
 # Karabiner auto-generated (managed by GokuRakuJoudo)
 .config/karabiner/


### PR DESCRIPTION
## 概要

Claude Code と Gemini CLI の両方から Superset 通知パイプライン (`\$SUPERSET_HOME_DIR/hooks/*.sh`) にセッション/ツールイベントを流し込むための hooks を追加。

## 変更点

- **`.claude/settings.json`**: 以下の hook 位置に Superset notify を追加
  - `SessionStart` / `SessionEnd`
  - `UserPromptSubmit`
  - `Stop`
  - `PostToolUse` (\`matcher: \"*\"\`)
  - `PostToolUseFailure`
  - `PermissionRequest`
- **`.gemini/settings.json`**: 同じくイベントに hook を追加
  - `SessionStart` / `SessionEnd`
  - `BeforeAgent` / `AfterAgent`
  - `AfterTool`
- **`.gitignore`**: Codex が自動生成する `.claude/skills/.system/` を除外

## 設計判断

- **ポータビリティ**: hook コマンドは絶対パスではなく `\$SUPERSET_HOME_DIR` 経由で解決。Superset 未インストール環境では `[ -n \"\$SUPERSET_HOME_DIR\" ] && [ -x ... ] && ... || true` の guard により no-op。他マシンで clone しても壊れない。
- **Gemini 側の path 統一**: 初期版で hardcode されていた \`/Users/takumiakasaka/.superset/hooks/gemini-hook.sh\` を \`\$SUPERSET_HOME_DIR\` 版に書き換え。
- **PR 分離**: \`skipDangerousModePermissionPrompt\` 設定と \`.claude/docs/research/nerdctl-tigron-migration.md\` はスコープ外として本 PR には含めない。

## テスト

- \`jq empty .claude/settings.json .gemini/settings.json\` で JSON validity 確認済み
- Superset 未インストール環境で guard が発火し hook が no-op になることは shell 展開的に自明 (\`[ -n \"\" ]\` が false)

## 注意点

破壊的変更なし。既存の hook (osascript notification, PostToolUse formatter 群) はそのまま維持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)