### PR TITLE
feat(quality-gate): add YAGNI review axis + fix codex worktree path

### DIFF
--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -81,6 +81,16 @@ All string fields (summary, problem, recommendation, notes_for_next_review) must
 - **Performance**: Bottlenecks, inefficient algorithms, resource leaks
 - **Maintainability**: Code readability, consistency with existing patterns, comments
 - **Testing**: Test coverage, test quality, missing test cases
+- **YAGNI / Simplicity** (critical — flag aggressively; AI-generated diffs routinely over-engineer):
+  - Unused features, config options, feature flags, or abstractions added "for future use"
+  - Defensive validation between internal callers (validate only at system boundaries: user input, external APIs). Trust internal code and framework guarantees.
+  - Unreachable error handling, fallbacks for states that cannot occur, catch blocks that hide bugs
+  - Comments that explain WHAT the code does (well-named identifiers already do that), TODO comments for hypothetical futures, "// added for X", caller references ("// used by Y"), "// removed" markers for deleted code
+  - Refactoring, renaming, or cleanup unrelated to the task's core purpose
+  - Helper functions abstracted from a single caller; premature DRY (three similar lines is fine)
+  - Backwards-compat shims, unused re-exports, renamed-but-unused `_var` placeholders left after deletion
+  - Any code that would be silently deleted without changing behavior
+  - Category: `maintainability`. Severity: `blocking` for clearly dead/unused code and clear defensive-coding violations; `advisory` for judgment calls where the extra code has borderline value.
 
 ## Previous Review Notes
 [Notes from previous iteration, if any]

--- a/.claude/skills/codex-review/SKILL.md
+++ b/.claude/skills/codex-review/SKILL.md
@@ -50,6 +50,18 @@ git diff HEAD --name-status --find-renames
 ROOT=$(git rev-parse --show-toplevel)
 REVIEW_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-review.XXXXXX")
 
+# Resolve schema path. In a git worktree, $ROOT is the worktree root (not the main
+# repo) — non-dotfiles projects won't have .claude/skills/ under it, so fall back
+# to $HOME/.claude/skills where the user-global skills live.
+if [ -f "$ROOT/.claude/skills/codex-review/review-schema.json" ]; then
+  SCHEMA_PATH="$ROOT/.claude/skills/codex-review/review-schema.json"
+elif [ -f "$HOME/.claude/skills/codex-review/review-schema.json" ]; then
+  SCHEMA_PATH="$HOME/.claude/skills/codex-review/review-schema.json"
+else
+  echo "ERROR: codex-review schema not found under \$ROOT or \$HOME/.claude/skills" >&2
+  exit 1
+fi
+
 # Portable timeout (zsh-safe array form). Falls back to perl alarm shim on macOS.
 if command -v gtimeout >/dev/null 2>&1; then
   TIMEOUT_CMD=(gtimeout 1200)
@@ -62,7 +74,7 @@ else
 fi
 
 "${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
-  --output-schema "$ROOT/.claude/skills/codex-review/review-schema.json" \
+  --output-schema "$SCHEMA_PATH" \
   -o "$REVIEW_OUT" \
   "$(cat <<'EOF'
 # Review Request
@@ -407,7 +419,7 @@ Claude Code constructs the prompt dynamically based on:
 ### Result Parsing
 - `--output-schema` guarantees JSON schema compliance via OpenAI structured output
 - `-o` outputs result to a unique temp file (via `mktemp`) — avoids stale reads and parallel conflicts
-- Schema paths use `$(git rev-parse --show-toplevel)` for location-independent execution
+- Schema paths resolve `$ROOT/.claude/skills/` first, then fall back to `$HOME/.claude/skills/` — required for git worktrees, where `$ROOT` points to the worktree root and typically lacks `.claude/skills/`
 - Always verify `codex exec` exit code and file non-emptiness before parsing (fail-closed)
 - `mktemp`, `codex exec`, verification, `jq` parse, and `rm -f` cleanup all run in the same shell block
 - Extract issues by severity for fixing
@@ -435,6 +447,16 @@ When triggered from **ExitPlanMode** (via quality-gate Step 1), Codex reviews th
 ROOT=$(git rev-parse --show-toplevel)
 PLAN_REVIEW_OUT=$(mktemp "${TMPDIR:-/tmp}/codex-plan-review.XXXXXX")
 
+# Resolve schema path — same worktree fallback rationale as Step 2.
+if [ -f "$ROOT/.claude/skills/codex-review/plan-review-schema.json" ]; then
+  PLAN_SCHEMA_PATH="$ROOT/.claude/skills/codex-review/plan-review-schema.json"
+elif [ -f "$HOME/.claude/skills/codex-review/plan-review-schema.json" ]; then
+  PLAN_SCHEMA_PATH="$HOME/.claude/skills/codex-review/plan-review-schema.json"
+else
+  echo "ERROR: codex-review plan-review schema not found under \$ROOT or \$HOME/.claude/skills" >&2
+  exit 1
+fi
+
 # Portable timeout (see Step 2 invariants — `< /dev/null`, `--ephemeral`, and TIMEOUT_CMD
 # are all required to prevent stdin hangs and session-file contention).
 if command -v gtimeout >/dev/null 2>&1; then
@@ -448,7 +470,7 @@ else
 fi
 
 "${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
-  --output-schema "$ROOT/.claude/skills/codex-review/plan-review-schema.json" \
+  --output-schema "$PLAN_SCHEMA_PATH" \
   -o "$PLAN_REVIEW_OUT" \
   "$(cat <<'EOF'
 # Plan Review Request

--- a/.claude/skills/gemini-review/SKILL.md
+++ b/.claude/skills/gemini-review/SKILL.md
@@ -86,6 +86,16 @@ $SAFE_DIFF
 - **Performance**: Bottlenecks, inefficient algorithms, resource leaks
 - **Maintainability**: Readability, consistency with existing patterns
 - **Testing**: Test coverage, test quality, missing test cases
+- **YAGNI / Simplicity** (critical — flag aggressively; AI-generated diffs routinely over-engineer):
+  - Unused features, config options, feature flags, or abstractions added "for future use"
+  - Defensive validation between internal callers (validate only at system boundaries: user input, external APIs). Trust internal code and framework guarantees.
+  - Unreachable error handling, fallbacks for states that cannot occur, catch blocks that hide bugs
+  - Comments that explain WHAT the code does (well-named identifiers already do that), TODO comments for hypothetical futures, "// added for X", caller references ("// used by Y"), "// removed" markers for deleted code
+  - Refactoring, renaming, or cleanup unrelated to the task's core purpose
+  - Helper functions abstracted from a single caller; premature DRY (three similar lines is fine)
+  - Backwards-compat shims, unused re-exports, renamed-but-unused `_var` placeholders left after deletion
+  - Any code that would be silently deleted without changing behavior
+  - Category: `maintainability`. Severity: `blocking` for clearly dead/unused code and clear defensive-coding violations; `advisory` for judgment calls where the extra code has borderline value.
 
 ## Output Format
 


### PR DESCRIPTION
## 概要

レビュースキル（codex-review / gemini-review）に **YAGNI / Simplicity** の評価軸を追加し、AI 生成コードが頻繁に混入させる過剰実装（未使用の抽象化・過剰防御・死にコメントなど）を検出できるようにする。あわせて、codex-review が git worktree で schema path の解決に失敗するバグを修正する。

## 変更点

### 1. `feat(quality-gate): YAGNI 軸を両レビューに追加`
`codex-review` / `gemini-review` の Review Focus Areas に **YAGNI / Simplicity** ブロックを追加。両レビュアーが以下を検出・指摘する:

- 「将来のため」の未使用機能・設定・抽象化
- 内部呼び出し間の防御的 validation（境界のみ OK）
- 到達不能な error handling / fallback
- WHAT を説明するコメント、caller 参照コメント、"// TODO 将来", "// added for X"
- タスクと無関係な便乗リファクタリング
- 単一 caller から抽出された helper、premature DRY
- 未使用の後方互換 shim / re-export

Category は既存の `maintainability` を流用。Severity は明らかな死コード = `blocking`、判断が分かれるもの = `advisory`。

**設計選択:**
- CLAUDE.md ではなく **skill 側に評価軸を埋め込む** → 常時ロードされる CLAUDE.md を肥大化させない
- quality-gate が自動で両レビュアーを並列起動するので、事後チェックは無償
- 生成時の予防は既存の Anthropic system prompt / 個別プロジェクトルール側に任せる

### 2. `fix(codex-review): worktree schema path フォールバック`
`--output-schema "$ROOT/.claude/skills/codex-review/review-schema.json"` が git worktree で失敗するバグを修正:

- `$ROOT = git rev-parse --show-toplevel` は worktree で **worktree ルート** を返す（main repo ルートではない）
- dotfiles 以外のプロジェクトの worktree では `$ROOT/.claude/skills/` が存在せず、`codex exec` がスキーマ読み込みで落ちる
- 修正: `$ROOT` を試して、無ければ `$HOME/.claude/skills/` にフォールバック。どちらも無ければ明示的エラー
- Step 2 (code review) と Plan Review Mode の 2 箇所に適用
- gemini-review は schema をプロンプトに埋め込んでいるため影響なし

## テスト

- [x] bash フォールバックロジックを単体で実行、`$ROOT` 不在時に `$HOME` 経由で schema が解決されることを確認
- [ ] 実 worktree 環境で quality-gate 起動テスト（次回 worktree 作業時に実効性を検証予定）
- [ ] YAGNI 軸が実 diff 上でどの程度指摘を上げるかは、次回のコード変更で経過観察

## 注意点

- CLAUDE.md には変更を加えていない（コンテキスト消費を抑える設計判断）
- gemini-review 側の schema はプロンプト埋め込みのため、path 修正は不要
- `.claude/settings.json` / `.gemini/settings.json` などセッション開始時に既に変更があった他ファイルは本 PR には含めていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)