### PR TITLE
feat(pr-comprehend): add PR digest skill for AI-authored PR review

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -19,7 +19,8 @@
 
 | Skill | Trigger | Description |
 |-------|---------|-------------|
-| quality-gate | After Edit/Write, before commit/PR | Format/lint/build + codex-review + gemini-review (parallel) |
+| quality-gate | After Edit/Write, before commit/PR | Format/lint/build + codex-review + gemini-review (parallel) + pr-comprehend digest |
+| pr-comprehend | Auto via quality-gate on commit (light) / PR (full) | 仕様/影響範囲/AI特有リスク digest を .claude/pr-review/ に保存 |
 | latest-docs | Before implementation | Verify latest documentation |
 | backend-go | Go implementation | Go backend best practices |
 | frontend-design | Figma implementation | Figma to code implementation |
@@ -31,6 +32,7 @@
 |-------|-------------|
 | codex-review | Code review via Codex |
 | gemini-review | Code review via Gemini (parallel with codex-review) |
+| pr-comprehend | 他人PRの digest (`pr-comprehend <PR番号>`) / ローカルブランチ振り返り (引数なし) |
 | web-research | 3者裏取りリサーチ (Claude + Codex + Gemini) |
 | test-generator | TDD: Generate tests before implementation |
 | security-scan | Security vulnerability scanning |

--- a/.claude/skills/pr-comprehend/SKILL.md
+++ b/.claude/skills/pr-comprehend/SKILL.md
@@ -1,0 +1,427 @@
+---
+name: pr-comprehend
+description: |
+  PR の仕様・影響範囲・AI特有リスクを網羅的に把握するための digest 生成 skill。
+  自分/AIが書いたPR、他人のPR、ローカルブランチのマージ前振り返り の 3 モード。
+  レポートは worktree 内 (.claude/pr-review/) に保存され、.git/info/exclude で自動的にコミット対象外。
+  quality-gate から commit / PR 作成前に自動発火する。
+metadata:
+  auto-trigger: false
+  invoked-by: [quality-gate, user]
+---
+
+# PR Comprehend
+
+## Purpose
+
+**「AI が書いた PR を、人間はどこまで読むべきか」問題への回答。**
+
+品質チェック (codex-review / gemini-review) は「何を直すべきか」に答えるが、
+それだけでは「この PR が何をやろうとしているのか」「どこに影響するのか」
+「AI が変な方向に走っていないか」は把握できない。
+
+この skill は **人間のレビュー負荷を下げる仕様把握レポート** を生成する。
+生の diff を人間が全部読まなくても、レポートを読めば全体像が掴める状態を目指す。
+
+## 3 Modes
+
+| Mode | 呼び出し | 対象 |
+|------|---------|------|
+| `author` | quality-gate から自動 | ローカルブランチの staged/unstaged 変更 |
+| `reviewer` | `pr-comprehend <PR番号>` | GitHub 上の他人 (or AI) の PR |
+| `self-recap` | `pr-comprehend` (引数なし) | ローカルブランチのマージ前振り返り |
+
+Mode の自動判定:
+- 引数に PR 番号 → `reviewer`
+- `quality-gate` から `--mode=author` 付きで呼ばれた → `author`
+- それ以外 → `self-recap`
+
+## Output Location
+
+**worktree 内 + コミット対象外** が要件。
+
+```
+.claude/pr-review/
+├── PR<番号>-<slug>.md        # reviewer mode
+├── local-<branch>-<hash>.md  # author / self-recap mode
+└── .gitkeep
+```
+
+### コミット対象外の担保
+
+skill 実行時に **`.git/info/exclude` に `.claude/pr-review/` を自動追加** する。
+`.git/info/exclude` は per-clone のローカル設定なので、共有 .gitignore を汚さない。
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null) || { echo "not in git repo"; exit 1; }
+EXCLUDE_FILE="$GIT_DIR/info/exclude"
+mkdir -p "$(dirname "$EXCLUDE_FILE")"
+touch "$EXCLUDE_FILE"
+if ! grep -qxF '.claude/pr-review/' "$EXCLUDE_FILE"; then
+  echo '.claude/pr-review/' >> "$EXCLUDE_FILE"
+fi
+mkdir -p .claude/pr-review
+```
+
+**注意**: dotfiles リポジトリ自体は `.gitignore` にも入れる (ソース管理側の意図明示)。
+
+## Execution Flow
+
+```
+┌────────────────────────────────────────────┐
+│  Step 0: Mode detection & prep             │
+│    → Detect mode (author/reviewer/self)    │
+│    → Ensure .git/info/exclude entry        │
+│    → Compute diff scope                    │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 1: Diff acquisition                  │
+│    author/self-recap: git diff BASE..HEAD  │
+│    reviewer:          gh pr diff <num>     │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 2: Weight decision (light vs full)   │
+│    trigger=commit  → light digest          │
+│    trigger=PR      → full digest           │
+│    trigger=manual  → full digest           │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 3: Delegate summarization to Gemini  │
+│    Large diff (>500 lines) → Gemini        │
+│    Small diff              → Claude inline │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 4: AI-specific risk scan via Codex   │
+│    (full mode only)                        │
+│    → hallucination / self-patch /          │
+│      over-abstraction / spec deviation     │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 5: Synthesize & save report          │
+│    → Merge Gemini summary + Codex risks    │
+│    → Write .claude/pr-review/<name>.md     │
+└────────────────────────────────────────────┘
+                    ↓
+┌────────────────────────────────────────────┐
+│  Step 6: Present to user (staged dialog)   │
+│    → 全体像を先に提示                        │
+│    → AskUserQuestion で深掘りセクション選択  │
+│    → (reviewer mode) --comment で PR 投稿   │
+└────────────────────────────────────────────┘
+```
+
+## Step 1: Diff Acquisition
+
+### author / self-recap mode
+
+```bash
+BASE=$(git merge-base HEAD origin/main 2>/dev/null || git merge-base HEAD main)
+# 変更ファイル一覧 + 統計
+git diff --stat "$BASE"..HEAD
+# 差分本体 (context 保護のため full diff は Gemini に投げる用)
+git diff "$BASE"..HEAD > /tmp/pr-comprehend-diff.$$.patch
+# ブランチ名 (ファイル名 slug 用)
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+HEAD_HASH=$(git rev-parse --short HEAD)
+```
+
+### reviewer mode
+
+```bash
+PR_NUM=$1
+gh pr view "$PR_NUM" --json title,body,author,baseRefName,headRefName,files > /tmp/pr-comprehend-meta.$$.json
+gh pr diff "$PR_NUM" > /tmp/pr-comprehend-diff.$$.patch
+```
+
+## Step 2: Weight Decision
+
+呼び出し元 (`--trigger` フラグ) で digest の重さを決める:
+
+| `--trigger` | 挙動 | Codex/Gemini 呼び出し |
+|---|---|---|
+| `commit` | **light digest** — Claude 内部で diff 要約のみ | なし |
+| `pr` | **full digest** — Gemini 要約 + Codex リスク検出 | あり |
+| `manual` (default) | **full digest** | あり |
+
+理由: commit ごとに Codex/Gemini を叩くとトークン消費が大きすぎる。
+commit 時は「今何が変わったか」の軽い記録として保存し、PR 作成時にフル分析する。
+
+### Light digest の内容
+
+- Section 1 (仕様サマリ) と Section 2 (影響範囲) のみ
+- Claude Code が git diff を直接読んで要約
+- Section 3-6 (リスク / AI特有 / チェックリスト / オープン質問) はスキップ
+
+### Full digest の内容
+
+- 全 6 セクション
+- Gemini に summarization を委譲、Codex に AI-specific risk 検出を委譲
+
+## Step 3: Delegate Summarization to Gemini
+
+**Context 保護のため、生 diff は Claude が読まない** (`.claude/rules/gemini-delegation.md` 準拠)。
+
+diff サイズが 500 行超なら Gemini に投げる:
+
+```bash
+DIFF_LINES=$(wc -l < /tmp/pr-comprehend-diff.$$.patch)
+if [ "$DIFF_LINES" -gt 500 ]; then
+  gemini -p "$(cat prompts/gemini-summary.md) $(cat /tmp/pr-comprehend-diff.$$.patch)" \
+    > /tmp/pr-comprehend-gemini.$$.md
+else
+  # 小さければ Claude が直接要約
+  cat /tmp/pr-comprehend-diff.$$.patch  # → 内部で要約
+fi
+```
+
+Gemini prompt (`prompts/gemini-summary.md`):
+
+```
+以下の git diff を読んで、日本語で以下を出力してください:
+
+## 1. 仕様サマリ (What changed)
+- API 変更 (追加/変更/削除)
+- UI 変更
+- DB スキーマ変更
+- 環境変数/設定変更
+- CLI 変更
+- Before → After の振る舞い差分
+
+## 2. 影響範囲マップ
+- 変更ファイルの呼び出し元 (推測でよい)
+- 破壊的変更の有無
+- データマイグレーションの必要性
+
+出力は事実ベース。推測は「(推測)」と明記。
+```
+
+## Step 4: AI-Specific Risk Scan via Codex
+
+Full digest 時のみ。Codex に **AI が書いた PR に特有のワナ** を検出させる。
+
+```bash
+ROOT=$(git rev-parse --show-toplevel)
+if [ -f "$ROOT/.claude/skills/pr-comprehend/digest-schema.json" ]; then
+  SCHEMA_PATH="$ROOT/.claude/skills/pr-comprehend/digest-schema.json"
+elif [ -f "$HOME/.claude/skills/pr-comprehend/digest-schema.json" ]; then
+  SCHEMA_PATH="$HOME/.claude/skills/pr-comprehend/digest-schema.json"
+else
+  echo "ERROR: digest-schema.json not found" >&2
+  exit 1
+fi
+
+DIGEST_OUT=$(mktemp "${TMPDIR:-/tmp}/pr-comprehend-digest.XXXXXX")
+
+# Portable timeout (codex-review と同じパターン)
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(gtimeout 900)
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_CMD=(timeout 900)
+else
+  TIMEOUT_CMD=()
+fi
+
+"${TIMEOUT_CMD[@]}" codex exec --model gpt-5.4 --sandbox read-only --ephemeral \
+  --output-schema "$SCHEMA_PATH" \
+  -o "$DIGEST_OUT" \
+  "$(cat prompts/codex-ai-risk.md)
+---DIFF---
+$(cat /tmp/pr-comprehend-diff.$$.patch)" < /dev/null
+
+CODEX_EXIT=$?
+if [ "$CODEX_EXIT" -ne 0 ] || [ ! -s "$DIGEST_OUT" ]; then
+  echo "WARN: codex ai-risk scan failed (exit=$CODEX_EXIT) — proceeding without" >&2
+  DIGEST_OUT=""
+fi
+```
+
+Codex prompt (`prompts/codex-ai-risk.md`) は AI 特有パターンに特化:
+- **Hallucination**: 存在しない関数/API/ライブラリの呼び出し
+- **Self-patch**: 自分が導入した throw を自分で catch している (quality-gate Step 2.5 と同型)
+- **Over-abstraction**: 単一呼び出しから helper 抽出、premature DRY
+- **Spec deviation**: PR タイトル/description に書かれた範囲外の変更
+- **Test water-filling**: assert のない test、mock だけで自己完結する test
+- **Dead code**: 削除すべきコメントアウトや unused import の追加
+
+出力は JSON schema (`digest-schema.json`) に従う。
+
+## Step 5: Synthesize & Save Report
+
+Gemini の仕様サマリ + Codex の AI-risk 結果を統合し、レポートを保存:
+
+```bash
+# ファイル名決定
+case "$MODE" in
+  reviewer)
+    SLUG=$(gh pr view "$PR_NUM" --json headRefName -q .headRefName | tr '/' '-')
+    REPORT="$ROOT/.claude/pr-review/PR${PR_NUM}-${SLUG}.md"
+    ;;
+  author|self-recap)
+    REPORT="$ROOT/.claude/pr-review/local-${BRANCH//\//-}-${HEAD_HASH}.md"
+    ;;
+esac
+```
+
+### Report Template (6 sections)
+
+```markdown
+# PR<番号> or local-<branch>: <title>
+
+**生成日時**: <ISO8601>
+**Mode**: <author|reviewer|self-recap>
+**Weight**: <light|full>
+**Base**: <base-ref>  **Head**: <head-ref>
+**変更**: <N files, +X -Y lines>
+
+---
+
+## 1. 仕様サマリ (What changed)
+
+<Gemini or Claude が生成した振る舞いレベルの要約>
+
+### API / UI / DB / 設定 の変更
+- [API] `POST /foo` を追加 (認証必須)
+- [UI] `<UserCard>` に status バッジを追加
+- [DB] `users.last_seen_at` カラムを追加 (nullable)
+- ...
+
+### Before → After
+- Before: ユーザー削除時は soft-delete のみ
+- After: 30日経過後に hard-delete する batch を追加
+
+---
+
+## 2. 影響範囲マップ (Blast radius)
+
+### 呼び出し関係
+- `handleDelete()` の変更 ← `UserSettings.tsx`, `AdminPanel.tsx` から呼ばれる
+- ...
+
+### 破壊的変更
+- [ ] API シェイプ変更あり: `/api/users` レスポンスに `deleted_at` 追加 (既存クライアント互換)
+- [ ] DB マイグレーション必要: `ALTER TABLE users ADD COLUMN last_seen_at`
+- [ ] 環境変数追加: `USER_HARD_DELETE_ENABLED`
+
+### データマイグレーション
+- 必要 / 不要
+- 必要な場合: ロールバック手順
+
+---
+
+## 3. リスク評価
+
+| 観点 | Level | 内容 |
+|---|---|---|
+| セキュリティ | Low/Med/High | ... |
+| 性能 | Low/Med/High | ... |
+| データ整合性 | Low/Med/High | ... |
+| 可観測性 | Low/Med/High | ... |
+
+---
+
+## 4. AI 特有リスク (最重要)
+
+<Codex ai-risk scan の結果>
+
+### Hallucination 疑い
+- `src/foo.ts:42` — 呼んでいる `parseFoo()` が定義されていない可能性
+
+### Self-patch (自己パッチ)
+- `src/bar.ts:88` — 同一 diff で `throw new BarError()` を追加し、
+  隣接ブロックで catch している
+
+### Over-abstraction
+- `src/util/helper.ts` — 1 箇所からしか呼ばれないヘルパー関数
+
+### Spec deviation (指示逸脱)
+- PR title は "Add user avatar" だが `src/auth/*` にも変更あり
+
+### Test 水増し
+- `test/foo.test.ts:15` — assert なしの test ケース
+
+### Dead code
+- コメントアウトされた `// old logic` が 3 箇所残存
+
+---
+
+## 5. レビュー観点チェックリスト (人間が確認)
+
+- [ ] 正当性: 主要 happy path が動くか
+- [ ] 正当性: エッジケース (null/empty/最大値) の考慮
+- [ ] セキュリティ: 認証/認可の抜け
+- [ ] セキュリティ: 入力バリデーション
+- [ ] 性能: N+1、無限ループ、無駄なフェッチ
+- [ ] エラーハンドリング: 例外の握り潰し
+- [ ] テスト網羅性: happy / error / edge
+
+---
+
+## 6. オープン質問 (人間が判断)
+
+- Q1: `USER_HARD_DELETE_ENABLED` のデフォルト値は false でよいか?
+- Q2: 30日という閾値の根拠は? 設定可能にすべきか?
+- ...
+```
+
+Light digest の場合は Section 3-6 を **「full digest 時に生成」** のプレースホルダにする。
+
+## Step 6: Present to User (Staged Dialog)
+
+レポート保存後、ユーザーに提示:
+
+```markdown
+📄 PR digest 生成完了: .claude/pr-review/<filename>.md
+
+## 全体像
+- **変更ファイル**: N
+- **主な変更**: <1行サマリ>
+- **破壊的変更**: あり/なし
+- **AI 特有リスク**: <High/Med/Low> — <上位1件>
+
+どこを詳しく見ますか? (数字で選択)
+1. 仕様サマリ
+2. 影響範囲
+3. リスク評価
+4. AI 特有リスク
+5. レビュー観点チェックリスト
+6. オープン質問
+0. スキップ (レポートは保存済み)
+```
+
+`AskUserQuestion` を使って対話的に深掘り。ユーザーがスキップすればレポートだけ残る。
+
+### `--comment` オプション (reviewer mode のみ)
+
+`pr-comprehend <PR番号> --comment` の場合、Section 1 (仕様サマリ) と Section 4 (AI特有リスク) を
+`gh pr comment <PR番号> --body-file <抜粋>` で GitHub PR に投稿。
+
+**投稿前に必ずユーザー確認**。自動投稿はしない (blast radius 大)。
+
+## Integration with quality-gate
+
+`quality-gate` の Step 4.7 で自動発火。詳細は `quality-gate/SKILL.md` を参照。
+
+- Trigger `commit`: light digest (Claude 内部要約のみ)
+- Trigger `pr`: full digest (Gemini + Codex 使用)
+
+## Error Handling
+
+| エラー | 対応 |
+|---|---|
+| `gh` CLI 未インストール (reviewer mode) | エラー表示、reviewer mode は使用不可 |
+| Gemini 未インストール | Claude で summarization にフォールバック |
+| Codex 失敗 | Section 4 (AI特有リスク) を「スキャン失敗」として記録し継続 |
+| diff が空 | 何もせず終了 |
+
+## Important
+
+- **Context 保護**: 大 diff の生読みは Claude ではなく Gemini に委譲する
+- **コミット防止**: 初回実行時に `.git/info/exclude` へ登録
+- **light/full の使い分け**: commit ごとに full digest を回さない (トークン浪費)
+- **--comment は必ず確認**: 自動投稿禁止
+- **日本語出力**: 全 user-facing text は日本語

--- a/.claude/skills/pr-comprehend/digest-schema.json
+++ b/.claude/skills/pr-comprehend/digest-schema.json
@@ -1,0 +1,207 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "PR Comprehend Digest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["summary", "blast_radius", "risks", "ai_risks", "review_checklist", "open_questions"],
+  "properties": {
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["one_liner", "changes", "before_after"],
+      "properties": {
+        "one_liner": {
+          "type": "string",
+          "description": "1行での変更サマリ (日本語)"
+        },
+        "changes": {
+          "type": "array",
+          "description": "カテゴリ別の変更一覧",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["category", "description"],
+            "properties": {
+              "category": {
+                "type": "string",
+                "enum": ["api", "ui", "db", "config", "cli", "docs", "test", "infra", "other"]
+              },
+              "description": {
+                "type": "string",
+                "description": "変更内容 (日本語)"
+              },
+              "files": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          }
+        },
+        "before_after": {
+          "type": "array",
+          "description": "振る舞いの Before → After 差分",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["before", "after"],
+            "properties": {
+              "before": {"type": "string"},
+              "after": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
+    "blast_radius": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["callers", "breaking_changes", "migration_required"],
+      "properties": {
+        "callers": {
+          "type": "array",
+          "description": "変更ファイルの主な呼び出し元",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["changed_file", "called_from"],
+            "properties": {
+              "changed_file": {"type": "string"},
+              "called_from": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          }
+        },
+        "breaking_changes": {
+          "type": "array",
+          "description": "破壊的変更 (API shape / DB schema / env var など)",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["kind", "detail"],
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": ["api_shape", "db_schema", "env_var", "cli_flag", "config_key", "other"]
+              },
+              "detail": {"type": "string"}
+            }
+          }
+        },
+        "migration_required": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "detail"],
+          "properties": {
+            "required": {"type": "boolean"},
+            "detail": {
+              "type": "string",
+              "description": "必要な場合はマイグレーション手順、不要な場合は空文字"
+            }
+          }
+        }
+      }
+    },
+    "risks": {
+      "type": "array",
+      "description": "一般的なリスク評価 (security/perf/data/observability)",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["axis", "level", "detail"],
+        "properties": {
+          "axis": {
+            "type": "string",
+            "enum": ["security", "performance", "data_integrity", "observability"]
+          },
+          "level": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "detail": {"type": "string"}
+        }
+      }
+    },
+    "ai_risks": {
+      "type": "array",
+      "description": "AI が書いた PR に特有のリスクパターン",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["pattern", "file", "line", "problem", "severity"],
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "enum": [
+              "hallucination",
+              "self_patch",
+              "over_abstraction",
+              "spec_deviation",
+              "test_water_filling",
+              "dead_code",
+              "premature_dry",
+              "unjustified_defensive"
+            ]
+          },
+          "file": {"type": "string"},
+          "line": {
+            "oneOf": [
+              {"type": "string"},
+              {"type": "integer"}
+            ]
+          },
+          "problem": {
+            "type": "string",
+            "description": "何が問題か (日本語)"
+          },
+          "severity": {
+            "type": "string",
+            "enum": ["blocking", "advisory"]
+          },
+          "recommendation": {
+            "type": "string",
+            "description": "推奨対応 (日本語、任意)"
+          }
+        }
+      }
+    },
+    "review_checklist": {
+      "type": "array",
+      "description": "人間のレビュアーが確認すべき観点",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["axis", "item"],
+        "properties": {
+          "axis": {
+            "type": "string",
+            "enum": [
+              "correctness",
+              "security",
+              "performance",
+              "error_handling",
+              "testing",
+              "docs",
+              "ops"
+            ]
+          },
+          "item": {"type": "string"}
+        }
+      }
+    },
+    "open_questions": {
+      "type": "array",
+      "description": "人間が判断すべき残課題",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["question"],
+        "properties": {
+          "question": {"type": "string"},
+          "context": {"type": "string"}
+        }
+      }
+    }
+  }
+}

--- a/.claude/skills/pr-comprehend/prompts/author-mode.md
+++ b/.claude/skills/pr-comprehend/prompts/author-mode.md
@@ -1,0 +1,81 @@
+# Author Mode
+
+このモードは **自分 (または AI) が書いた変更を PR 化する前に振り返る** ためのもの。
+
+## 前提
+
+- ローカルブランチに未 push または push 済みだが merge 前の変更がある
+- quality-gate から `--mode=author --trigger=<commit|pr>` で呼ばれる
+- または手動で `pr-comprehend --mode=author` として呼ぶ
+
+## Extra prompts to inject
+
+Author mode では、Codex ai-risk scan に以下を追加で問う:
+
+```
+## Author-mode extra checks
+
+このユーザーは AI 支援でこの変更を書いた可能性が高い。以下を特に警戒せよ:
+
+1. **指示逸脱**: このセッションで依頼されたはずのタスク範囲を超える変更が入っていないか
+   (別ファイルの refactor が混入している、命名規則の一括変更が混じっている 等)
+
+2. **元コードの意図的削除**: 削除された行のうち、意味論的に必要そうに見えるものが
+   コミットメッセージや変更説明で言及されていないか
+
+3. **設定/依存の忍び込み**: package.json / go.mod / requirements.txt / .env* / config/*
+   への変更が本来のタスクに必要か
+
+4. **AI が「よかれと思って」書いた冗長コード**:
+   - JSDoc / docstring の大量追加 (元コードに無かったのに)
+   - 型注釈の過剰な明示 (推論で十分な箇所)
+   - 変数の過剰な rename ("data" → "userDataResponse" 等)
+
+## Output guidance
+
+これらは severity=advisory で ai_risks[] に追加。
+ただし「元の意図が明らかに破壊されている」場合は blocking。
+```
+
+## Report file naming
+
+```
+.claude/pr-review/local-<branch>-<HEAD_hash>.md
+```
+
+同じブランチで再度 skill を実行するとファイル名が変わる (HEAD hash 違い) が、
+古いレポートは自動削除しない。手動で `.claude/pr-review/` を掃除する。
+
+## Weight rules
+
+- `--trigger=commit` → light digest (Claude 内部要約のみ、Codex/Gemini 不使用)
+  - 目的: commit ごとの軽い記録。トークン消費を抑える
+- `--trigger=pr` → full digest
+  - 目的: PR 作成前の網羅的振り返り。時間もトークンも使う
+
+## Present to user
+
+Full digest の場合、対話提示の最初のメッセージ:
+
+```
+📄 PR digest 生成完了 (author mode, full)
+   .claude/pr-review/<filename>.md
+
+## 全体像
+- 変更ファイル: <N> / 追加行: <+X> / 削除行: <-Y>
+- 主な変更: <one_liner>
+- 破壊的変更: <あり/なし> (<breaking_changes 上位1件>)
+- AI 特有リスク: <High/Med/Low> — <ai_risks 上位1件>
+
+このまま PR を作成しますか? それとも先に digest を確認しますか?
+```
+
+Light digest の場合:
+
+```
+📝 commit digest 保存 (light mode)
+   .claude/pr-review/<filename>.md
+   <one_liner>
+```
+
+Light は 1 行報告のみ。詳細確認は促さない (commit 頻度が高いので割り込み最小化)。

--- a/.claude/skills/pr-comprehend/prompts/codex-ai-risk.md
+++ b/.claude/skills/pr-comprehend/prompts/codex-ai-risk.md
@@ -1,0 +1,106 @@
+# AI-Specific Risk Scan
+
+You are auditing a PR that was authored (partially or entirely) by an AI coding assistant.
+Your job is to detect patterns that are **overrepresented in AI-generated diffs** compared to human-written diffs.
+
+Output MUST conform to the provided JSON schema (`digest-schema.json`).
+All string fields (problem, recommendation, context, description, detail, item, question) MUST be in Japanese.
+
+## Patterns to Detect
+
+For each pattern found, emit an entry in `ai_risks[]` with:
+- `pattern`: one of the enum values below
+- `file`: path
+- `line`: line number or range
+- `problem`: 何が問題か (Japanese)
+- `severity`: `blocking` for clear issues, `advisory` for judgment calls
+- `recommendation`: 推奨対応 (Japanese, optional but strongly encouraged)
+
+### 1. `hallucination`
+The diff calls a function/method/API/library that does not appear to exist.
+- Uses `parseFoo()` but no such function is imported or defined in the diff or nearby files
+- Imports from a package that is not in package.json / go.mod / Cargo.toml / pyproject.toml
+- References a config key that is not defined anywhere
+
+Severity: **blocking** (this will fail at runtime)
+
+### 2. `self_patch`
+The diff introduces both a `throw` AND a `catch` for that same throw. The AI created a problem
+and then "solved" it in the same diff. Genuine error handling handles errors from OTHER code,
+not from the same commit.
+
+Also flag: new defensive `if (!x)` guards where `x` is set to a non-null value earlier in the same diff.
+
+Severity: **blocking** (the underlying bug is being hidden, not fixed)
+
+### 3. `over_abstraction`
+- New helper function called from exactly 1 place
+- Premature DRY: 2-3 similar lines extracted into a function/class
+- New abstract base class / interface with only 1 implementation
+- Generic parameter / type parameter with only 1 concrete usage in the diff
+
+Severity: `advisory` (unless it obscures logic significantly, then `blocking`)
+
+### 4. `spec_deviation`
+PR title / description mentions X, but the diff also modifies Y that is unrelated.
+Examples:
+- PR title: "Add user avatar" but changes to `src/auth/` or `src/billing/`
+- PR title: "Fix typo in README" but changes to actual source files
+- Diff includes formatting-only changes in files unrelated to the stated task
+
+Severity: `advisory` if benign refactor, `blocking` if unrelated behavior change
+
+### 5. `test_water_filling`
+Tests that don't actually assert meaningful behavior:
+- Test body calls the function but has no `expect` / `assert` / `require`
+- Test only checks that the mock was called (not that behavior is correct)
+- Test asserts `true === true` or equivalent tautology
+- Test's mocks are so tight that only the mock behavior is tested, not the real code path
+- Test name says "should X" but the assertion doesn't verify X
+
+Severity: **blocking** (fake test coverage is worse than no test — creates false confidence)
+
+### 6. `dead_code`
+- Commented-out code (`// old logic`, `# TODO remove`)
+- Unused imports added by the diff
+- Unused variables/parameters (except in interface implementations)
+- Unreachable branches (`if (false)`, code after `return`)
+- Renamed-but-unused `_var` placeholders
+
+Severity: `blocking` for obviously dead code, `advisory` for judgment calls
+
+### 7. `premature_dry`
+Similar to over_abstraction but specifically for the "3 similar lines → helper" antipattern.
+The rule of thumb: **3 similar lines is fine**. Only extract when there are 5+ usages OR the
+duplication is genuinely error-prone.
+
+Severity: `advisory`
+
+### 8. `unjustified_defensive`
+New defensive code that guards against states that cannot occur:
+- Null check on a parameter that is typed as non-null
+- try/catch around code that cannot throw (e.g., `Math.max`, string concatenation)
+- Validation of internal function arguments (validate at system boundary only)
+- Fallback branch for a condition that is exhaustively covered above
+
+Severity: `blocking` (this is the exact anti-pattern the codebase-wide YAGNI rule targets)
+
+## Also Fill
+
+Beyond `ai_risks[]`, produce best-effort content for:
+
+- `summary`: If Gemini summary is available in context, echo/refine it. Otherwise, derive from diff.
+- `blast_radius`: Callers you can identify, breaking changes, migration needs.
+- `risks`: General risk axes (security / performance / data_integrity / observability).
+- `review_checklist`: 7-15 items a human reviewer should verify, tailored to what the diff touches.
+- `open_questions`: Decisions the human should make (defaults, thresholds, naming, rollout).
+
+## Rules
+
+- All Japanese fields must be natural Japanese (not machine translation).
+- Do NOT invent findings to pad the report. Empty arrays are fine when nothing is found.
+- Prefer specific file:line references over vague statements.
+- For hallucination/self_patch/test_water_filling: if you are unsure, err toward NOT flagging
+  (false positives are more costly than false negatives here — the human still reads the diff).
+
+The diff follows below.

--- a/.claude/skills/pr-comprehend/prompts/gemini-summary.md
+++ b/.claude/skills/pr-comprehend/prompts/gemini-summary.md
@@ -1,0 +1,60 @@
+You are analyzing a git diff to produce a Japanese specification digest for a human reviewer.
+
+Read the provided diff carefully. Do NOT invent behavior that is not visible in the code.
+For anything you inferred (rather than directly observed), prefix with "(推測)".
+
+Output the following two sections in Japanese Markdown:
+
+## 1. 仕様サマリ (What changed)
+
+Break down changes by category. Skip categories with no changes.
+
+### API
+- 追加/変更/削除された endpoint、request/response shape、authentication requirement
+
+### UI
+- 追加/変更された component、visible behavior change、visual difference
+
+### DB
+- Schema change (table, column, index, constraint), migration necessity
+
+### CLI
+- Added/changed/removed command, flag, subcommand
+
+### 設定 (config)
+- Environment variable, config key, feature flag
+
+### その他
+- Internal helper, refactoring, dependency change
+
+### Before → After (振る舞い差分)
+List meaningful behavior differences. Format:
+- Before: <観察された過去の振る舞い>
+  After: <観察された新しい振る舞い>
+
+## 2. 影響範囲マップ (Blast radius)
+
+### 主な呼び出し関係
+For each significantly changed file/function, list the callers you can identify from the diff or common convention.
+- `<changed_file>::<symbol>` ← called from: `<file1>`, `<file2>` ...
+
+### 破壊的変更 (Breaking changes)
+Explicit list. Empty section if none.
+- [API shape] ...
+- [DB schema] ...
+- [Env var] ...
+- [CLI flag] ...
+
+### データマイグレーション
+- 必要: yes / no
+- 必要な場合: マイグレーション手順の概略 + ロールバック可否
+
+---
+
+**Rules**:
+- 事実ベースで書く。diff に無い挙動を勝手に補完しない
+- 推測は "(推測)" を明記
+- 出力はすべて日本語
+- 全体で 800 語程度に収める (要約が目的)
+
+The diff follows this instruction below:

--- a/.claude/skills/pr-comprehend/prompts/reviewer-mode.md
+++ b/.claude/skills/pr-comprehend/prompts/reviewer-mode.md
@@ -1,0 +1,130 @@
+# Reviewer Mode
+
+このモードは **他人 (人間 or AI) が出した GitHub PR を人間として把握する** ためのもの。
+
+## 前提
+
+- GitHub 上の PR を対象とする
+- `pr-comprehend <PR番号>` で呼び出す
+- `gh` CLI が必要 (未インストール時はエラー)
+
+## Data acquisition
+
+```bash
+PR_NUM=$1
+gh pr view "$PR_NUM" --json title,body,author,baseRefName,headRefName,files,additions,deletions,labels,url \
+  > /tmp/pr-comprehend-meta.$$.json
+gh pr diff "$PR_NUM" > /tmp/pr-comprehend-diff.$$.patch
+```
+
+Author が bot / AI アカウントかを heuristic 判定:
+- `author.login` が `github-actions[bot]`, `dependabot[bot]`, `claude-code[bot]` 等
+- PR body に `🤖 Generated with [Claude Code]` などのフッタあり
+- label に `ai-generated` 等がある
+
+判定結果を Codex prompt に注入する ("author is likely AI" hint)。
+
+## Extra prompts to inject
+
+Reviewer mode では、Codex ai-risk scan に以下を追加で問う:
+
+```
+## Reviewer-mode extra checks
+
+このレビュアーはこの PR のコンテキストを持たない。以下を明示的に説明せよ:
+
+1. **PR タイトル/description との整合性**:
+   - PR title: <inject>
+   - PR body: <inject (最初の 500 文字)>
+   - diff がこの description の範囲と一致しているか?
+   - description に無い変更があれば `spec_deviation` として ai_risks[] に記録
+
+2. **暗黙の前提**:
+   - この PR は何かを前提としているか (feature flag が有効、DB migration が先に適用済み等)
+   - 前提が満たされない環境で merge した場合の挙動は?
+   - `open_questions[]` にレビュアーが確認すべき前提を列挙
+
+3. **レビュアーが試すべき動作確認**:
+   - この diff を確認するために手元で何を実行すればよいか
+   - `review_checklist[]` の `axis=ops` に具体的な検証手順を書く
+
+## Output guidance
+
+- Author が AI と判定された場合、ai_risks[] のスキャンをより厳しく
+- Author が人間の場合、hallucination / self_patch のスキャンは軽めでよい
+  (人間はハルシネートしにくいが、他パターンは同様に警戒)
+```
+
+## Report file naming
+
+```
+.claude/pr-review/PR<番号>-<head-branch-slug>.md
+```
+
+同じ PR で複数回実行するとファイルは上書き。
+
+## Present to user
+
+```
+📄 PR #<番号> digest 生成完了
+   .claude/pr-review/PR<番号>-<slug>.md
+   <PR URL>
+
+## 全体像
+- Title: <title>
+- Author: <login> (<AI判定結果>)
+- 変更: <files> files, +<additions> -<deletions>
+- 主な変更: <one_liner>
+- 破壊的変更: <あり/なし>
+- AI 特有リスク: <レベル> — <上位1件>
+
+どこを詳しく見ますか?
+1. 仕様サマリ
+2. 影響範囲
+3. リスク評価
+4. AI 特有リスク
+5. レビュー観点チェックリスト (手元で試す手順を含む)
+6. オープン質問
+0. スキップ
+```
+
+## `--comment` option
+
+`pr-comprehend <PR番号> --comment` の場合、以下の内容で PR にコメント投稿:
+
+**投稿前に必ずユーザーに投稿内容を提示し、明示的な承認を得る**。自動投稿は絶対にしない。
+
+投稿本文テンプレート:
+
+```markdown
+## 🤖 PR Digest (by pr-comprehend)
+
+### 仕様サマリ
+<summary.one_liner>
+
+<summary.changes を category ごとに箇条書き>
+
+### 影響範囲
+- 破壊的変更: <あり/なし>
+- マイグレーション必要: <yes/no>
+
+### レビュアー向けチェック
+<review_checklist の主要 5-7 項目>
+
+### 気になる点 (要確認)
+<ai_risks の blocking 全件 + advisory 上位 3件>
+
+### 質問
+<open_questions>
+
+---
+_この digest はレビュー支援用の自動生成です。実際の判断は人間のレビュアーがしてください。_
+```
+
+投稿コマンド:
+```bash
+BODY_FILE=$(mktemp)
+# ... build body ...
+gh pr comment "$PR_NUM" --body-file "$BODY_FILE"
+rm -f "$BODY_FILE"
+```

--- a/.claude/skills/pr-comprehend/prompts/self-recap-mode.md
+++ b/.claude/skills/pr-comprehend/prompts/self-recap-mode.md
@@ -1,0 +1,78 @@
+# Self-Recap Mode
+
+このモードは **自分のローカルブランチをマージ前に振り返る** ためのもの。
+Author mode に近いが、想定シチュエーションが違う:
+- Author mode: これから PR にする直前
+- Self-recap mode: PR は作成済み or ローカルで熟成中、時間が経って「何やってたっけ?」となった状態
+
+## 前提
+
+- ローカルブランチに変更あり (base branch と diff がある)
+- `pr-comprehend` (引数なし) で呼び出す
+- quality-gate からは呼ばれない (これは手動専用)
+
+## Extra prompts to inject
+
+Self-recap mode では、Codex ai-risk scan に以下を追加で問う:
+
+```
+## Self-recap-mode extra checks
+
+このユーザーはこのブランチの変更を書いてから時間が経過している可能性が高い。
+「自分でやったが忘れていること」を思い出せるように digest を書け。
+
+1. **コミット間の一貫性**:
+   - `git log` を確認できる範囲で、各コミットのメッセージと実際の diff が
+     整合しているか
+   - コミットメッセージに書かれていない変更がまとめて 1 コミットに混入していないか
+
+2. **最初の意図との乖離**:
+   - 最初のコミット (base の直後) と最後のコミット (HEAD) を比べて、
+     途中でアプローチを変えた形跡があるか
+   - 変えた場合、古いアプローチの残骸が残っていないか (dead_code として ai_risks[] に)
+
+3. **忘れやすい前提**:
+   - 環境変数の設定、DB migration の適用、依存パッケージのインストールなど
+     マージ前に必ず必要な準備を `open_questions[]` に列挙
+
+## Output guidance
+
+- one_liner は「時間が経ったユーザーが 5 秒で思い出せる」ような要約に
+- ai_risks[] の severity は Author mode と同基準
+```
+
+## Report file naming
+
+Author mode と同じ命名。
+```
+.claude/pr-review/local-<branch>-<HEAD_hash>.md
+```
+
+## Present to user
+
+```
+📄 self-recap digest 生成完了
+   .claude/pr-review/local-<branch>-<hash>.md
+
+## このブランチで何をしていたか
+<one_liner>
+
+## 変更全体像
+- 変更ファイル: <N> / <+X -Y lines>
+- 最初のコミット: <first commit hash + subject>
+- 最新のコミット: <HEAD hash + subject>
+- 破壊的変更: <あり/なし>
+- 途中でアプローチ変更: <あり/なし>
+
+## 次にやるべきこと (推測)
+<open_questions から抜粋>
+
+詳しく見ますか?
+1. 仕様サマリ
+2. 影響範囲
+3. リスク評価
+4. AI 特有リスク / 忘れ物
+5. マージ前チェックリスト
+6. オープン質問
+0. スキップ
+```

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -57,6 +57,13 @@ Ensure code quality through automated checks before any user-facing action.
 └─────────────────────────────────────────────────────┘
                         ↓
 ┌─────────────────────────────────────────────────────┐
+│  4.7. PR Spec Digest (via pr-comprehend)            │
+│     → commit trigger: light digest (Claude only)    │
+│     → PR trigger:     full digest (Gemini + Codex)  │
+│     → Report → .claude/pr-review/ (git-excluded)    │
+└─────────────────────────────────────────────────────┘
+                        ↓
+┌─────────────────────────────────────────────────────┐
 │  5. Behavior Verification (Runtime Smoke)           │
 │     → Format/lint/unit tests verify CODE, not       │
 │       FEATURE correctness. Run an actual smoke      │
@@ -406,6 +413,82 @@ def merge_reviews(codex_result, gemini_result, gemini_status):
 - **Both agree blocking**: Highest priority fix
 - Max 5 iterations (same as before)
 
+## Step 4.7: PR Spec Digest (via pr-comprehend)
+
+Review 結果評価と behavior verification の間に **仕様把握レポート** を生成する。
+これは quality (何を直すか) ではなく comprehension (何が変わったか) を担う。
+
+**目的**:
+- AI が書いた PR を人間がレビューする際の認知負荷を下げる
+- 「AI が指示逸脱していないか」「hallucination がないか」を機械的に検出
+- レポートはローカル worktree に保存し、必要に応じて PR body に添付
+
+### Trigger 判定
+
+quality-gate は呼び出しコンテキストに応じて digest の重さを変える:
+
+| quality-gate の起点 | pr-comprehend trigger | digest weight |
+|---|---|---|
+| commit 直前 | `commit` | light (Claude 内部要約のみ) |
+| PR 作成/更新 直前 | `pr` | full (Gemini 要約 + Codex AI-risk scan) |
+| ExitPlanMode | — | 実行しない (まだコードが無い) |
+| user confirmation | 通常 skip | full を明示要求された場合のみ |
+
+**Rationale**: commit ごとに Gemini/Codex を叩くとトークン浪費が大きい。commit 時は軽い記録のみ、
+PR 時にフル分析する。ただし「commit も PR も自動発火」というユーザー要求は満たす。
+
+### 実行手順
+
+```bash
+# 1. .git/info/exclude に登録 (初回のみ、以降は no-op)
+GIT_DIR=$(git rev-parse --git-dir)
+EXCLUDE_FILE="$GIT_DIR/info/exclude"
+mkdir -p "$(dirname "$EXCLUDE_FILE")" && touch "$EXCLUDE_FILE"
+grep -qxF '.claude/pr-review/' "$EXCLUDE_FILE" || echo '.claude/pr-review/' >> "$EXCLUDE_FILE"
+mkdir -p .claude/pr-review
+
+# 2. pr-comprehend skill を呼び出し
+#    Trigger は quality-gate の起点から自動判定
+case "$QUALITY_GATE_TRIGGER" in
+  commit) TRIGGER=commit ;;
+  pr)     TRIGGER=pr ;;
+  *)      TRIGGER=manual ;;
+esac
+
+# Skill 呼び出し (実装: pr-comprehend/SKILL.md 参照)
+# quality-gate 側では skill=pr-comprehend を Skill tool 経由で呼ぶ
+```
+
+Skill invocation (Claude が実行):
+```
+Skill(skill="pr-comprehend", args="--mode=author --trigger=<TRIGGER>")
+```
+
+### 結果の扱い
+
+- **light digest (commit trigger)**:
+  - 1 行報告のみユーザーに提示: `📝 commit digest: <one_liner>`
+  - 詳細確認プロンプトは出さない (割り込み最小化)
+  - `.claude/pr-review/local-<branch>-<hash>.md` に保存されている
+
+- **full digest (pr trigger)**:
+  - 全体像 + セクション選択プロンプトをユーザーに提示
+  - ユーザーが選んだセクションを深掘り
+  - `pr` skill と連携: 生成した digest のパスを PR body 末尾に `<!-- pr-comprehend: <path> -->` として追記可能
+
+### エラー時の挙動
+
+- `pr-comprehend` が失敗しても quality-gate は blocking しない (Step 5 へ進む)
+- 失敗理由をユーザーに通知: `⚠️ PR digest 生成に失敗: <reason>`
+- 後で `pr-comprehend` を手動再実行できるよう案内
+
+### 除外条件
+
+以下の場合 Step 4.7 はスキップ:
+- diff が空
+- `.claude/`, `docs/`, `*.md` のみの変更 (レビュー観点が薄い)
+- ユーザーが `QUALITY_GATE_NO_DIGEST=1` を設定
+
 ## Step 5: Behavior Verification (Runtime Smoke)
 
 **Format/lint/unit tests verify CODE correctness, NOT FEATURE correctness.**
@@ -457,6 +540,7 @@ surfaces is exactly the class that lint/type/unit cannot catch.
 - ALWAYS wait for at least Codex to complete
 - Gemini failure is non-blocking (proceed with Codex only)
 - Fix ALL Codex blocking issues before proceeding
+- ALWAYS run Step 4.7 (PR spec digest) — light for commit, full for PR. Non-blocking on failure
 - ALWAYS run Step 5 (behavior verification) before declaring done — and if you cannot,
   say so explicitly rather than implying success
 - Document any skipped checks with reason

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,8 @@
 # Codex-managed system skills (auto-installed)
 .claude/skills/.system/
 
+# pr-comprehend skill output (local-only, per-worktree)
+.claude/pr-review/
+
 # Karabiner auto-generated (managed by GokuRakuJoudo)
 .config/karabiner/


### PR DESCRIPTION
## 概要

AI が書いた PR / 他人の PR / 自分のブランチを「網羅的に把握」するための新規 skill `pr-comprehend` を追加。品質チェック (`codex-review` / `gemini-review`) が扱えていない **仕様把握 (comprehension)** レイヤを担う。

**背景**: AI 開発が進むにつれ「AI が書いた PR をどこまで人間がレビューすべきか」問題が顕在化。生 diff を全部読むのは非現実的、レビュー観点だけでは何が変わったか掴めない。

## 変更点

### 新規 skill: `pr-comprehend`
- **3 モード**: `author` (自 PR 直前) / `reviewer` (他人 PR) / `self-recap` (ローカルブランチ振り返り)
- **6 セクションレポート**: 仕様サマリ / 影響範囲 / リスク評価 / AI 特有リスク / レビュー観点 / オープン質問
- **8 種類の AI 特有リスク検出** (Codex 委譲): hallucination / self_patch / over_abstraction / spec_deviation / test_water_filling / dead_code / premature_dry / unjustified_defensive
- **保存先**: `.claude/pr-review/` (skill 実行時に `.git/info/exclude` へ自動追加 → 任意 repo で worktree 汚染なし、コミットもされない)
- **Context 保護**: 500 行超の diff は Gemini に summarization 委譲

### quality-gate との統合 (Step 4.7)
- **commit trigger**: light digest (Claude 内部要約のみ、1 行報告) — トークン浪費回避
- **pr trigger**: full digest (Gemini + Codex 起動、対話的セクション選択)
- 失敗しても non-blocking
- `.claude/` / `docs/` / `*.md` のみの変更ではスキップ

### CLAUDE.md / .gitignore
- Auto Skills / Manual Skills 表に `pr-comprehend` 追加
- `.gitignore` に `.claude/pr-review/` 追加 (dotfiles 側のソース管理意図明示)

## テスト

- SKILL.md フロントマターが有効 → skill 一覧に自動認識確認済み
- `digest-schema.json` は valid JSON
- `.git/info/exclude` 追加ロジックは冪等 (`grep -qxF`)
- 実 PR での動作確認は merge 後に本 PR 自体を対象に `pr-comprehend $(この PR 番号)` で試行予定

## 注意点

- 破壊的変更なし
- quality-gate は failure-mode で non-blocking なので、pr-comprehend が壊れても既存フローに影響なし
- commit ごとに light digest が 1 行だけ出るようになる (割り込みは最小化)
- `QUALITY_GATE_NO_DIGEST=1` で無効化可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)