### PR TITLE
feat(pr): auto-assign PR author with @me

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -275,12 +275,18 @@ If a template file is found, read its contents with the Read tool.
       🤖 Generated with [Claude Code](https://claude.com/claude-code)
       ```
 
-3. Create PR:
+3. Create PR (always self-assign with `--assignee @me`):
    ```bash
-   gh pr create --title "{title}" --body "$(cat <<'EOF'
+   gh pr create --assignee @me --title "{title}" --body "$(cat <<'EOF'
    {body content}
    EOF
    )"
+   ```
+
+   If `--assignee @me` fails (e.g. the account can't be resolved), create the
+   PR without it and then self-assign as a follow-up:
+   ```bash
+   gh pr edit {pr-number} --add-assignee @me
    ```
 
 **If PR already exists (update):**
@@ -292,9 +298,9 @@ If a template file is found, read its contents with the Read tool.
    - Update all sections with the latest content (not just append)
    - Add any new notes/caveats if applicable
 
-3. Update PR:
+3. Update PR (also ensure self-assignment — no-op if already assigned):
    ```bash
-   gh pr edit {pr-number} --body "$(cat <<'EOF'
+   gh pr edit {pr-number} --add-assignee @me --body "$(cat <<'EOF'
    {updated body content}
    EOF
    )"
@@ -374,6 +380,7 @@ chore: update dependencies → chore/update-dependencies
 6. **Use kebab-case** for branch names (lowercase with hyphens)
 7. **Determine branch prefix from commit type**, not manually specified
 8. **Validate arbitrary branch names** from editors like Superset in Step 1.5 — propose a rename before push when the name doesn't follow convention (never rename silently)
+9. **Always self-assign the PR** with `--assignee @me` on create (and `--add-assignee @me` on update) so the PR is owned by the author automatically
 
 ## Output Format to User
 


### PR DESCRIPTION
## 概要
`/pr` コマンドで PR を作成・更新する際、作者（自分）を自動でアサインするようにした。

## 変更点
- **新規作成時**: `gh pr create --assignee @me` で自動的に自己アサイン
- **フォールバック**: `@me` の解決に失敗した場合は PR 作成後に `gh pr edit --add-assignee @me` でフォローアップ
- **更新時**: `gh pr edit --add-assignee @me` を追加（既にアサイン済みなら no-op）
- **Important Notes に項目9追加**: 自己アサインを常時行うルールを明文化

## テスト
- Markdown（コマンド定義）のみの変更のため format/lint/build は N/A
- この PR 自体が新しい自己アサイン挙動で作成されており、動作確認を兼ねている

## 注意点
- `@me` は gh CLI が認証中のアカウントに解決されるため、ユーザー名のハードコード不要で環境非依存

🤖 Generated with [Claude Code](https://claude.com/claude-code)