### PR TITLE
feat(setup): add install phase for fresh-Mac bootstrap

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -156,6 +156,158 @@ verify_setup() {
     info "All symlinks verified successfully!"
 }
 
+# Install Homebrew if it is not already present
+install_homebrew() {
+    step "Setting up Homebrew..."
+    if command -v brew &>/dev/null; then
+        info "Homebrew already installed"
+    else
+        info "Installing Homebrew..."
+        # Download and run separately so a curl failure is not masked by the
+        # command substitution (an empty script would otherwise exit 0).
+        local installer
+        if ! installer="$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"; then
+            warn "Homebrew installer download failed. Skipping package installation."
+            return 0
+        fi
+        if ! /bin/bash -c "$installer"; then
+            warn "Homebrew install failed. Skipping package installation."
+            return 0
+        fi
+    fi
+
+    # Ensure brew is on PATH for the rest of this script (Apple Silicon / Intel)
+    if [ -x /opt/homebrew/bin/brew ]; then
+        eval "$(/opt/homebrew/bin/brew shellenv)"
+    elif [ -x /usr/local/bin/brew ]; then
+        eval "$(/usr/local/bin/brew shellenv)"
+    fi
+}
+
+# Install every package declared in the Brewfile
+brew_bundle() {
+    step "Installing packages from Brewfile..."
+    if ! command -v brew &>/dev/null; then
+        warn "brew not available. Skipping brew bundle."
+        return 0
+    fi
+
+    local brewfile="$DOTFILES_DIR/.homebrew/Brewfile"
+    if [ ! -f "$brewfile" ]; then
+        warn "Brewfile not found at $brewfile. Skipping."
+        return 0
+    fi
+
+    info "Running brew bundle (this may take a while)..."
+    brew bundle --file="$brewfile" || warn "brew bundle reported failures (continuing)."
+}
+
+# Install language runtimes declared in .tool-versions via asdf
+install_asdf_tools() {
+    step "Installing runtimes from .tool-versions..."
+    if ! command -v asdf &>/dev/null; then
+        warn "asdf not found. Skipping runtime installation."
+        return 0
+    fi
+
+    local tool_versions="$DOTFILES_DIR/.tool-versions"
+    if [ ! -f "$tool_versions" ]; then
+        warn ".tool-versions not found. Skipping."
+        return 0
+    fi
+
+    # Add each required plugin (skip ones already installed; keep stderr visible
+    # so genuine failures such as a typo'd plugin name remain diagnosable)
+    local plugin _rest installed
+    installed="$(asdf plugin list 2>/dev/null || true)"
+    while read -r plugin _rest; do
+        [ -z "$plugin" ] && continue
+        case "$plugin" in \#*) continue ;; esac
+        grep -qxF "$plugin" <<<"$installed" && continue
+        asdf plugin add "$plugin" || warn "asdf plugin add $plugin failed (continuing)."
+    done <"$tool_versions"
+
+    # Install the pinned versions from $HOME (where .tool-versions is symlinked)
+    (cd "$HOME" && asdf install) || warn "asdf install reported issues (continuing)."
+}
+
+# Generate the Karabiner config from the GokuRakuJoudo .edn source
+generate_karabiner() {
+    step "Generating Karabiner config with goku..."
+    if ! command -v goku &>/dev/null; then
+        warn "goku not found. Skipping Karabiner generation."
+        return 0
+    fi
+
+    GOKU_EDN_CONFIG_FILE="$HOME/.config/gokurakujoudo/karabiner.edn" goku ||
+        warn "goku generation failed (continuing)."
+}
+
+# Set sensible global git defaults (aligned with existing zsh aliases)
+# Each config is non-fatal so a failure never triggers the EXIT-trap rollback.
+configure_git() {
+    step "Configuring global git settings..."
+    git config --global init.defaultBranch main || warn "git config init.defaultBranch failed"
+    git config --global push.autoSetupRemote true || warn "git config push.autoSetupRemote failed"
+    git config --global pull.ff only || warn "git config pull.ff failed"
+    git config --global fetch.prune true || warn "git config fetch.prune failed"
+    git config --global rerere.enabled true || warn "git config rerere.enabled failed"
+    info "Global git settings applied."
+}
+
+# Apply a standard developer set of macOS system preferences
+configure_macos_defaults() {
+    if [[ "$(uname)" != "Darwin" ]]; then
+        info "Not macOS. Skipping system defaults."
+        return 0
+    fi
+
+    step "Applying macOS system defaults..."
+
+    # Absorb any single-key failure (e.g. an unsupported key on a different macOS
+    # version) so it never escapes to `set -e` and fires the EXIT-trap rollback.
+    local d="defaults write"
+    {
+        # Keyboard: fastest key repeat + disable press-and-hold accent popup
+        $d NSGlobalDomain KeyRepeat -int 2
+        $d NSGlobalDomain InitialKeyRepeat -int 15
+        $d NSGlobalDomain ApplePressAndHoldEnabled -bool false
+
+        # Trackpad: disable natural scroll direction
+        $d NSGlobalDomain com.apple.swipescrolldirection -bool false
+
+        # Dock: auto-hide instantly, no recents
+        $d com.apple.dock autohide -bool true
+        $d com.apple.dock autohide-delay -float 0
+        $d com.apple.dock autohide-time-modifier -float 0
+        $d com.apple.dock show-recents -bool false
+
+        # Screenshots: save to ~/Screenshots as shadowless PNGs
+        mkdir -p "$HOME/Screenshots"
+        $d com.apple.screencapture location -string "$HOME/Screenshots"
+        $d com.apple.screencapture disable-shadow -bool true
+        $d com.apple.screencapture type -string "png"
+
+        # Finder: show extensions, hidden files, path/status bars, list view, POSIX path
+        $d NSGlobalDomain AppleShowAllExtensions -bool true
+        $d com.apple.finder AppleShowAllFiles -bool true
+        $d com.apple.finder ShowPathbar -bool true
+        $d com.apple.finder ShowStatusBar -bool true
+        $d com.apple.finder FXPreferredViewStyle -string "Nlsv"
+        $d com.apple.finder _FXShowPosixPathInTitle -bool true
+        $d com.apple.finder FXEnableExtensionChangeWarning -bool false
+
+        # Misc: no .DS_Store on network volumes, always show scrollbars
+        $d com.apple.desktopservices DSDontWriteNetworkStores -bool true
+        $d NSGlobalDomain AppleShowScrollBars -string "Always"
+    } || warn "Some macOS defaults could not be applied (continuing)."
+
+    # Restart affected apps so changes take effect immediately
+    killall Dock Finder SystemUIServer &>/dev/null || true
+
+    info "macOS system defaults applied."
+}
+
 echo "======================================"
 echo "  Dotfiles Setup"
 echo "  Source: $DOTFILES_DIR"
@@ -164,6 +316,12 @@ echo ""
 
 # Run pre-flight checks
 preflight_check
+
+# Install phase: Homebrew + every package in the Brewfile (goku, asdf, etc.)
+install_homebrew
+brew_bundle
+
+echo ""
 
 # Root dotfiles
 step "Setting up root dotfiles..."
@@ -226,6 +384,14 @@ verify_setup
 
 echo ""
 
+# Post-symlink provisioning (needs symlinked configs + installed tools)
+install_asdf_tools
+generate_karabiner
+configure_git
+configure_macos_defaults
+
+echo ""
+
 # Post-install: AI tool setup
 step "Setting up AI tools..."
 
@@ -253,7 +419,10 @@ echo ""
 echo "Notes:"
 echo "  - Backup files created with .bak extension (timestamped if exists)"
 echo "  - Local secrets stay in ~/.zsh/secrets.zsh (not symlinked)"
-echo "  - Run 'goku' to generate Karabiner config from .edn"
+echo "  - Packages installed from .homebrew/Brewfile via 'brew bundle'"
+echo "  - Runtimes installed from .tool-versions via 'asdf install'"
+echo "  - Karabiner config generated from .edn via 'goku'"
+echo "  - macOS system defaults applied (some need a logout/restart)"
 echo "  - RTK: Restart Claude Code for hook to take effect"
 echo "  - agent-browser: Run 'agent-browser install' if Chromium was not installed"
 echo ""


### PR DESCRIPTION
## 概要

`setup.sh` を「シンボリックリンクを繋ぐだけ」から「新品 Mac で一発フルセットアップ」に拡張。leonsilicon の bootstrap-macos の思想（設定を配るのではなくセットアップ手順を自動実行する）を、既存の堅牢な symlink 基盤（rollback / backup / verify 付き）の上に載せた。

## 変更点

install 工程を6ステップ追加（すべて非致命・冪等）:

- `install_homebrew` — brew 無ければ公式スクリプトで導入 + PATH 通し（Apple Silicon / Intel 両対応）。curl の DL と実行を2段階に分離し、ネット障害時の失敗握りつぶしを防止
- `brew_bundle` — `.homebrew/Brewfile`（179 packages）を `brew bundle` で一括インストール（goku・asdf もここで入る）
- `install_asdf_tools` — `.tool-versions` を asdf plugin add → install（既存プラグインはスキップ）
- `generate_karabiner` — `GOKU_EDN_CONFIG_FILE` 経由で `goku` を実行し Karabiner 設定を生成
- `configure_git` — `init.defaultBranch main` / `push.autoSetupRemote` / `pull.ff only`（既存 alias と整合）/ `fetch.prune` / `rerere`
- `configure_macos_defaults` — 定番フルセット（キーリピート最速・Dock 自動非表示・スクショ保存先&影なし・Finder 表示系・ナチュラルスクロール OFF 等）

実行順: preflight → brew 導入 → brew bundle → symlink → asdf → goku → git → macOS defaults → AI tools → verify。symlink を install 後の asdf/goku より前に置くことで、symlink 済みの `.tool-versions` / `.edn` を参照できる。

## 設計上のポイント

- 新規 install ステップは `set -euo pipefail` + `trap cleanup EXIT` の rollback を誤発火させないよう、`command -v` ガード・`|| warn`・`return 0`・brace group `{ ... } || warn` で非致命化。任意ツールが未導入でも fresh-machine run が中断しない
- 既存の RTK / agent-browser post-install と同じ非致命パターンを踏襲

## テスト

- `bash -n` 構文チェック: パス
- `.tool-versions` パースロジック・パス解決・関数配線の smoke: パス
- codex-review: `ok: true`（2 イテレーション、blocking 2件を修正）
- gemini-review: 環境要因で CLI 起動不可 → 直接レビューで代替（blocking 1件を修正）

## 注意点

- ⚠️ **実 macOS 上でのフル挙動は未検証**（この環境では Homebrew 導入・`defaults write`・Dock/Finder kill が実マシンを変更するため安全に実行不可）。マージ前に実機または使い捨て VM で `./setup.sh` を一度流すことを推奨
- macOS defaults の一部（キーリピート等）は反映にログアウト / 再起動が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)