### PR TITLE
chore: add shellcheck CI and fix hardcoded paths

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -11,13 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
-        env:
-          SHELLCHECK_OPTS: -e SC1090 -e SC1091
-        with:
-          severity: warning
-          # zsh scripts are not supported by ShellCheck:
-          #   review-pr.sh -> #!/bin/zsh
-          #   ide.sh       -> sourced zsh helper (no shebang)
-          ignore_names: review-pr.sh ide.sh
+      - name: Run ShellCheck on bash scripts
+        shell: bash
+        run: |
+          # Lint only bash scripts. zsh is unsupported by shellcheck, so the
+          # sourced .zsh fragments, .zshrc/.zprofile, review-pr.sh (#!/bin/zsh)
+          # and the shebang-less ide.sh are intentionally excluded by matching
+          # on a bash shebang.
+          mapfile -t files < <(grep -rlE '^#!.*\bbash\b' --include='*.sh' . | sort)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No bash scripts found."; exit 0
+          fi
+          printf 'Linting:\n'; printf '  %s\n' "${files[@]}"
+          shellcheck --severity=warning "${files[@]}"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: ShellCheck
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        env:
+          SHELLCHECK_OPTS: -e SC1090 -e SC1091
+        with:
+          severity: warning
+          # zsh scripts are not supported by ShellCheck:
+          #   review-pr.sh -> #!/bin/zsh
+          #   ide.sh       -> sourced zsh helper (no shebang)
+          ignore_names: review-pr.sh ide.sh

--- a/.zsh/init.zsh
+++ b/.zsh/init.zsh
@@ -22,7 +22,7 @@ autoload -Uz compinit
 compinit -i -d "${XDG_CACHE_HOME:-$HOME/.cache}/zsh/zcompdump-$ZSH_VERSION-$HOST"
 
 ## docker desktop
-[ -f /Users/takumiakasaka/.docker/init-zsh.sh ] && source /Users/takumiakasaka/.docker/init-zsh.sh
+[ -f "$HOME/.docker/init-zsh.sh" ] && source "$HOME/.docker/init-zsh.sh"
 
 ## starship
 eval "$(starship init zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -11,7 +11,7 @@ for file in "${ZSH_DIR}"/*.zsh; do
 done
 
 # Added by Windsurf
-export PATH="/Users/takumiakasaka/.codeium/windsurf/bin:$PATH"
+export PATH="$HOME/.codeium/windsurf/bin:$PATH"
 
 [[ "$TERM_PROGRAM" == "kiro" ]] && . "$(kiro --locate-shell-integration-path zsh)"
 

--- a/setup.sh
+++ b/setup.sh
@@ -54,7 +54,8 @@ preflight_check() {
     step "Running pre-flight checks..."
     local failed=0
 
-    # Check for required commands
+    # Check for required commands (list kept as a loop for easy extension)
+    # shellcheck disable=SC2043
     for cmd in git; do
         if ! command -v "$cmd" &>/dev/null; then
             error "Required command not found: $cmd"
@@ -429,6 +430,7 @@ echo ""
 
 # Check if secrets.zsh exists
 if [ ! -f "$HOME/.zsh/secrets.zsh" ]; then
+    # shellcheck disable=SC2088  # literal path shown to the user, not expanded
     warn "~/.zsh/secrets.zsh not found."
     if [ -f "$DOTFILES_DIR/.zsh/secrets.zsh.template" ]; then
         echo "  Run: cp $DOTFILES_DIR/.zsh/secrets.zsh.template ~/.zsh/secrets.zsh"


### PR DESCRIPTION
## 概要
新品 Mac ブートストラップ (#213) の目標に沿って、移植性を壊すハードコードパスを修正し、シェルスクリプトの回帰を防ぐ shellcheck CI を追加しました。

## 変更点
- **fix**: `/Users/takumiakasaka` 決め打ちの絶対パスを `$HOME` に置換
  - `.zshrc` — Windsurf の PATH 追加行
  - `.zsh/init.zsh` — Docker `init-zsh.sh` の source 行（クォートも付与）
- **ci**: `.github/workflows/shellcheck.yml` を追加（push(main) / 全 PR で発火）
  - 検査対象: `setup.sh`, `.script/*.sh` の bash スクリプト
  - 除外: `review-pr.sh`（`#!/bin/zsh`）と source 用 `ide.sh` — shellcheck は zsh 非対応のため
  - `setup.sh` に disable ディレクティブ 2件（SC2043 / SC2088、いずれも意図的）を付与し CI を初回から green に

## テスト
- `shellcheck setup.sh .script/dev.sh .script/review.sh` → CLEAN
- `.github/workflows/shellcheck.yml` → YAML 妥当性確認済み
- `zsh -n .zshrc / .zsh/init.zsh` → 構文 OK

## 注意点
- 破壊的変更なし（設定パスの `$HOME` 化と CI 追加のみ）
- `.config/prr/config.toml` にも同種のハードコードパスが残存。prr が TOML 内の `~`/`$HOME` を展開するか未確認のため本 PR では未対応

🤖 Generated with [Claude Code](https://claude.com/claude-code)