### PR TITLE
feat: enable brew autoupdate via official tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,43 @@ vim ~/.zsh/secrets.zsh
 goku
 ```
 
+## Homebrew 自動アップデート
+
+Homebrew 公式タップ [`brew autoupdate`](https://github.com/DomT4/homebrew-autoupdate)
+で定期自動更新します（launchd で background 実行）。`setup.sh` の実行時に自動で
+有効化されます。
+
+```bash
+# setup.sh が内部で実行する内容（手動で実行する場合）
+brew tap domt4/autoupdate
+brew trust domt4/autoupdate   # Homebrew 6+ はサードパーティ tap に trust が必要
+brew autoupdate start --upgrade --ac-only --notify-on-error
+
+# 状態確認 / ログ / 停止
+brew autoupdate status
+brew autoupdate logs
+brew autoupdate stop
+```
+
+- `--upgrade`: formula/cask を実際にアップグレード（付けないと `brew update` の
+  メタデータ更新のみ）
+- `--ac-only`: 電源接続時のみ実行（バッテリー消費を避ける）
+- `--notify-on-error`: 失敗時のみ通知
+- `--cleanup` は**あえて付けていない**（旧バージョンを Cellar に残し、壊れた時に
+  `brew unlink`/`brew link` で戻せるようにするため）。ディスクを掃除したい場合のみ
+  `brew autoupdate start --upgrade --cleanup ...` で付け直す。
+
+### 特定 formula を自動更新から除外したい場合
+
+`brew autoupdate` に除外リストは無いため、凍結したいものは `brew pin` します
+（`brew autoupdate --upgrade` は pin された formula を上げません）。
+
+```bash
+brew pin asdf openjdk   # 例: 勝手に上げたくないツールを凍結
+brew unpin asdf         # 解除
+brew list --pinned      # 現在の凍結一覧
+```
+
 ## トラブルシューティング
 
 ### setup.shが失敗する

--- a/setup.sh
+++ b/setup.sh
@@ -203,6 +203,38 @@ brew_bundle() {
     brew bundle --file="$brewfile" || warn "brew bundle reported failures (continuing)."
 }
 
+# Keep Homebrew up to date automatically via the official autoupdate tap
+enable_brew_autoupdate() {
+    step "Enabling brew autoupdate..."
+    if ! command -v brew &>/dev/null; then
+        warn "brew not available. Skipping autoupdate."
+        return 0
+    fi
+
+    brew tap domt4/autoupdate &>/dev/null || warn "Could not tap domt4/autoupdate."
+    # Homebrew 6+ refuses to run commands from third-party taps until trusted.
+    brew trust domt4/autoupdate &>/dev/null || warn "Could not trust domt4/autoupdate tap."
+
+    # Idempotent: the tool writes this LaunchAgent plist when configured, so its
+    # presence means a schedule already exists — leave it as-is.
+    local plist="$HOME/Library/LaunchAgents/com.github.domt4.homebrew-autoupdate.plist"
+    if [ -f "$plist" ]; then
+        info "brew autoupdate already configured."
+        return 0
+    fi
+
+    # --ac-only avoids draining the battery; --notify-on-error surfaces failures
+    # only. `--cleanup` is intentionally omitted so old versions stay in the
+    # Cellar and a bad upgrade can be rolled back with `brew unlink`/`brew link`.
+    # Pinned formulae (brew pin) are never upgraded — use those to freeze
+    # anything you don't want bumped automatically.
+    if brew autoupdate start --upgrade --ac-only --notify-on-error; then
+        info "brew autoupdate started (24h interval, AC power only)."
+    else
+        warn "brew autoupdate failed to start (continuing)."
+    fi
+}
+
 # Install language runtimes declared in .tool-versions via asdf
 install_asdf_tools() {
     step "Installing runtimes from .tool-versions..."
@@ -321,6 +353,7 @@ preflight_check
 # Install phase: Homebrew + every package in the Brewfile (goku, asdf, etc.)
 install_homebrew
 brew_bundle
+enable_brew_autoupdate
 
 echo ""
 


### PR DESCRIPTION
## 概要

Homebrew を常に最新へ保つため、公式タップ [`brew autoupdate`](https://github.com/DomT4/homebrew-autoupdate)（DomT4/homebrew-autoupdate）を `setup.sh` の install フェーズで自動有効化する。自作の更新スクリプトではなく既製ツールに寄せることで、メンテ負担ゼロで定期自動更新を実現する。

## 変更点

- **setup.sh**: `enable_brew_autoupdate()` を追加し、install フェーズ（`brew_bundle` の後）で呼び出し
  - `brew tap domt4/autoupdate` → `brew trust domt4/autoupdate`（Homebrew 6+ はサードパーティ tap の trust が必須）→ `brew autoupdate start --upgrade --ac-only --notify-on-error`
  - LaunchAgent plist（`com.github.domt4.homebrew-autoupdate.plist`）の存在で冪等化。再実行しても二重起動しない
  - `--cleanup` はあえて付けず、旧バージョンを Cellar に残して手動ロールバック可能にする
  - `brew` 未検出時は early-return（既存 `brew_bundle` と同じ作法）
- **README.md**: 「Homebrew 自動アップデート」節を追加（使い方・オプション・`brew pin` による個別凍結の説明）

## 挙動

- 登録後は **1日ごとに launchd が自動で `brew update` + `brew upgrade`**（AC電源時のみ / 失敗時のみ通知）
- 自動更新させたくないツールは `brew pin <formula>` で凍結（autoupdate は pin を上げない）
- `--greedy` 未指定のため、自前で自動更新する GUI アプリ（Cursor / Claude 等）は対象外

## テスト

- `bash -n setup.sh` / `shellcheck --severity=warning setup.sh`（CI と同基準）クリア
- LaunchAgent plist ラベルをツール本体ソース（`lib/autoupdate/core.rb`）で確認し冪等判定の正当性を検証
- 実機で `brew tap` → `brew trust` → `brew autoupdate start` を実行し、`brew autoupdate status` が "installed and running" になることを確認
- Codex レビュー: BLOCKING / ADVISORY ともになし

## 注意点

破壊的変更なし。既に `brew autoupdate` を設定済みの環境では冪等ガードによりスキップされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)