### PR TITLE
fix(setup): link .claude/rules into ~/.claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ chmod 600 ~/.zsh/secrets.zsh
 
 ```
 .
-├── .claude/          # Claude Code設定（skills, commands, plugins）
+├── .claude/          # Claude Code設定（skills, commands, rules, plugins）
 ├── .codex/           # Codex CLI設定
 ├── .config/          # アプリケーション設定
 │   ├── alacritty/    # ターミナルエミュレータ

--- a/setup.sh
+++ b/setup.sh
@@ -393,6 +393,7 @@ create_symlink "$DOTFILES_DIR/.claude/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
 create_symlink "$DOTFILES_DIR/.claude/settings.json" "$HOME/.claude/settings.json"
 create_symlink "$DOTFILES_DIR/.claude/commands" "$HOME/.claude/commands"
 create_symlink "$DOTFILES_DIR/.claude/skills" "$HOME/.claude/skills"
+create_symlink "$DOTFILES_DIR/.claude/rules" "$HOME/.claude/rules"
 create_symlink "$DOTFILES_DIR/.claude/plugins" "$HOME/.claude/plugins"
 
 # .gemini directory (selective - keep auth/history local)


### PR DESCRIPTION
## 概要

`setup.sh` は `.claude` 配下の `CLAUDE.md` / `settings.json` / `commands` / `skills` / `plugins` を
`~/.claude` へ symlink するが、`rules` だけが対象外だった。結果として `~/.claude/rules` が存在せず、
`.claude/rules/*.md` は dotfiles リポジトリ内で作業しているときにしか読み込まれない。

`CLAUDE.md` は `.claude/rules/flow-gates.md`（ゲートの成立条件）と
`.claude/rules/comment-policy.md`（コメント・PR 文面の判定基準）を単一の情報源として参照しているため、
他プロジェクトではこれらの参照先が存在しない状態になっていた。

## 変更点

- `setup.sh`: `.claude/rules` → `~/.claude/rules` の symlink を追加（`skills` と `plugins` の間）
- `README.md`: ディレクトリ説明に `rules` を追記

## 影響範囲

- 新たに `~/.claude/rules` が作られる。同名の実体が既にある場合は `create_symlink` が
  `.bak` へ退避してから張り替える（既存の他項目と同じ挙動）
- 既に正しい symlink がある場合は `Already linked` で no-op。再実行しても安全

## 検証方法

- `shellcheck setup.sh` → 警告なし（CI と同じ検査）
- 手元で symlink を作成し、`~/.claude/rules/` から 8 ファイル
  （`flow-gates.md` `comment-policy.md` `coding-principles.md` 他）が見えることを確認
- symlink の target が `$DOTFILES_DIR/.claude/rules` と一致することを確認。
  次回 `setup.sh` 実行時に `Already linked` となり冪等

## 既知の制約

Claude Code が `~/.claude/rules/*.md` を**グローバルに自動読み込みするかは未確認**。
この PR は「`.claude` 配下の資産のうち `rules` だけがリンクされていない」という配置の不整合を直すもので、
他プロジェクトで実際に読み込まれるかは別セッションでの確認が必要。
読み込まれない場合は `CLAUDE.md` 側に明示的な参照を足す対応が別途要る。


🤖 Generated with [Claude Code](https://claude.com/claude-code)